### PR TITLE
Create OrthancServer.main.cpp

### DIFF
--- a/Patches/OrthancServer.main.cpp
+++ b/Patches/OrthancServer.main.cpp
@@ -1,0 +1,15 @@
+--- main.cpp	2014-09-19 11:46:51.000000000 +0300
++++ main.updated.cpp	2014-12-05 16:05:21.000000000 +0200
+@@ -681,6 +681,12 @@
+   {
+     LOG(ERROR) << "Uncaught exception, stopping now: [" << e.What() << "]";
+     status = -1;
++  } catch (const std::exception& e) {
++    LOG(ERROR) << "Exception: [" << e.what() << "]";
++    status = -1;
++  } catch (const std::string& s) {
++    LOG(ERROR) << "Exception: [" << s << "]";
++    status = -1;
+   }
+   catch (...)
+   {


### PR DESCRIPTION
Exceptions with description. Otherwise server dies without informing the cause of death, i.e. before:
E1205 16:47:57.365274 30204 main.cpp:687] Native exception, stopping now
after
E1205 16:49:51.910228 30268 main.cpp:685] Exception: [locale::facet::_S_create_c_locale name not valid]
