### PR TITLE
Update link to the DWV Orthanc plugin

### DIFF
--- a/Plugins/README.md
+++ b/Plugins/README.md
@@ -11,7 +11,7 @@ Orthanc plugins must use the [plugin SDK](https://code.google.com/p/orthanc/sour
 ## Viewers
 
 * [Orthanc Web Viewer](https://code.google.com/p/orthanc-webviewer/): This **official** plugin extends Orthanc with a Web viewer of medical images.
-* [DwvExplorer](https://github.com/ivmartel/DwvExplorer): This plugin is based on [DWV](https://github.com/ivmartel/dwv/wiki) by Yves Martel.
+* [DWV Orthanc Plugin](https://github.com/ivmartel/dwv-orthanc-plugin): This plugin is based on [dwv](https://github.com/ivmartel/dwv/wiki) by ivmartel.
 
 ## HTML
 


### PR DESCRIPTION
The name of the plugin has changed from DwvExplorer to dwv-orthanc-plugin.