### PR TITLE
Add NamingScheme and WriteRedundant to Object Storage plugin

### DIFF
--- a/Plugins/orthanc-s3-namingscheme/Aws/AwsS3StoragePlugin.cpp
+++ b/Plugins/orthanc-s3-namingscheme/Aws/AwsS3StoragePlugin.cpp
@@ -1,0 +1,881 @@
+/**
+ * Cloud storage plugins for Orthanc
+ * Copyright (C) 2020-2023 Osimis S.A., Belgium
+ * Copyright (C) 2024-2026 Orthanc Team SRL, Belgium
+ * Copyright (C) 2021-2026 Sebastien Jodogne, ICTEAM UCLouvain, Belgium
+ *
+ * This program is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ **/
+
+#include "AwsS3StoragePlugin.h"
+#include <Logging.h>
+
+#include <aws/core/Aws.h>
+#include <aws/s3/S3Client.h>
+#include <aws/s3/model/PutObjectRequest.h>
+#include <aws/s3/model/GetObjectRequest.h>
+#include <aws/s3/model/ListObjectsRequest.h>
+#include <aws/s3/model/DeleteObjectRequest.h>
+#include <aws/s3/model/PutObjectTaggingRequest.h>
+#include <aws/s3/model/Tag.h>
+#include <aws/core/auth/AWSCredentialsProvider.h>
+#include <aws/core/utils/HashingUtils.h>
+#include <aws/core/utils/logging/DefaultLogSystem.h>
+#include <aws/core/utils/logging/DefaultCRTLogSystem.h>
+#include <aws/core/utils/logging/AWSLogging.h>
+#include <aws/core/utils/memory/stl/AWSStreamFwd.h>
+#include <aws/core/utils/memory/stl/AWSStringStream.h>
+#include <aws/core/utils/memory/AWSMemory.h>
+#include <aws/core/utils/stream/PreallocatedStreamBuf.h>
+#include <aws/core/utils/StringUtils.h>
+#include <aws/transfer/TransferManager.h>
+#include <aws/crt/Api.h>
+#include <iostream>
+#include <fstream>
+
+#include <boost/lexical_cast.hpp>
+#include <boost/interprocess/streams/bufferstream.hpp>
+#include <iostream>
+#include <fstream>
+
+const char* ALLOCATION_TAG = "OrthancS3";
+
+class AwsS3StoragePlugin : public BaseStorage
+{
+public:
+
+  std::string             bucketName_;
+  bool                    storageContainsUnknownFiles_;
+  bool                    useTransferManager_;
+  std::shared_ptr<Aws::S3::S3Client>               client_;
+  std::shared_ptr<Aws::Utils::Threading::Executor> executor_;
+  std::shared_ptr<Aws::Transfer::TransferManager>  transferManager_;
+  Aws::S3::Model::StorageClass                     storageClass_;
+  std::map<std::string, std::string> tags_;
+
+public:
+
+  AwsS3StoragePlugin(const std::string& nameForLogs, 
+                     std::shared_ptr<Aws::S3::S3Client> client, 
+                     const std::string& bucketName, 
+                     bool enableLegacyStorageStructure, 
+                     bool storageContainsUnknownFiles, 
+                     bool useTransferManager, 
+                     unsigned int transferThreadPoolSize, 
+                     unsigned int transferBufferSizeMB, 
+                     Aws::S3::Model::StorageClass storageClass,
+                     const std::map<std::string, std::string>& tags);
+
+  virtual ~AwsS3StoragePlugin();
+
+  virtual IWriter* GetWriterForObject(const char* uuid, OrthancPluginContentType type, bool encryptionEnabled) ORTHANC_OVERRIDE;
+  virtual IReader* GetReaderForObject(const char* uuid, OrthancPluginContentType type, bool encryptionEnabled) ORTHANC_OVERRIDE;
+  virtual void DeleteObject(const char* uuid, OrthancPluginContentType type, bool encryptionEnabled) ORTHANC_OVERRIDE;
+
+  // Custom path support
+  virtual IWriter* GetWriterForObject(const char* uuid, OrthancPluginContentType type, bool encryptionEnabled, const std::string& customPath) ORTHANC_OVERRIDE;
+  virtual IReader* GetReaderForObject(const char* uuid, OrthancPluginContentType type, bool encryptionEnabled, const std::string& customPath) ORTHANC_OVERRIDE;
+  virtual void DeleteObject(const char* uuid, OrthancPluginContentType type, bool encryptionEnabled, const std::string& customPath) ORTHANC_OVERRIDE;
+
+  virtual bool HasFileExists() ORTHANC_OVERRIDE
+  {
+    return false;
+  }
+};
+
+static void SetTags(std::shared_ptr<Aws::S3::S3Client> client, const std::string& bucketName, const std::string& path, const std::map<std::string, std::string>& tags)
+{
+  if (tags.size() > 0)
+  {
+    Aws::S3::Model::PutObjectTaggingRequest taggingRequest;
+    taggingRequest.SetBucket(bucketName.c_str());
+    taggingRequest.SetKey(path.c_str());
+
+    Aws::S3::Model::Tagging tagging;
+
+    for (std::map<std::string, std::string>::const_iterator it = tags.begin(); it != tags.end(); ++it)
+    {
+      Aws::S3::Model::Tag tag;
+      tag.SetKey(it->first);
+      tag.SetValue(it->second);
+      tagging.AddTagSet(tag);
+    }
+    
+    taggingRequest.SetTagging(tagging);
+    auto taggingResult = client->PutObjectTagging(taggingRequest);
+
+    if (!taggingResult.IsSuccess())
+    {
+      throw StoragePluginException(std::string("error while tagging file ") + path + ": response code = " + boost::lexical_cast<std::string>((int)taggingResult.GetError().GetResponseCode()) + " " + taggingResult.GetError().GetExceptionName().c_str() + " " + taggingResult.GetError().GetMessage().c_str());
+    }
+  }
+}
+
+
+class DirectWriter : public IStorage::IWriter
+{
+  std::string                           path_;
+  std::shared_ptr<Aws::S3::S3Client>    client_;
+  std::string                           bucketName_;
+  Aws::S3::Model::StorageClass          storageClass_;
+  std::map<std::string, std::string>    tags_;
+
+public:
+  DirectWriter(std::shared_ptr<Aws::S3::S3Client> client, const std::string& bucketName, const std::string& path, Aws::S3::Model::StorageClass storageClass, const std::map<std::string, std::string>& tags)
+    : path_(path),
+      client_(client),
+      bucketName_(bucketName),
+      storageClass_(storageClass),
+      tags_(tags)
+  {
+  }
+
+  virtual ~DirectWriter()
+  {
+  }
+
+  virtual void Write(const char* data, size_t size) ORTHANC_OVERRIDE
+  {
+    Aws::S3::Model::PutObjectRequest putObjectRequest;
+
+    putObjectRequest.SetBucket(bucketName_.c_str());
+    putObjectRequest.SetKey(path_.c_str());
+
+    if (storageClass_ != Aws::S3::Model::StorageClass::NOT_SET)
+    {
+      putObjectRequest.SetStorageClass(storageClass_);
+    }
+
+    std::shared_ptr<Aws::StringStream> stream = Aws::MakeShared<Aws::StringStream>(ALLOCATION_TAG, std::ios_base::in | std::ios_base::binary);
+
+    stream->rdbuf()->pubsetbuf(const_cast<char*>(data), size);
+    stream->rdbuf()->pubseekpos(size);
+    stream->seekg(0);
+
+    putObjectRequest.SetBody(stream);
+    putObjectRequest.SetContentMD5(Aws::Utils::HashingUtils::Base64Encode(Aws::Utils::HashingUtils::CalculateMD5(*stream)));
+
+    auto result = client_->PutObject(putObjectRequest);
+
+    if (!result.IsSuccess())
+    {
+      throw StoragePluginException(std::string("error while writing file ") + path_ + ": response code = " + boost::lexical_cast<std::string>((int)result.GetError().GetResponseCode()) + " " + result.GetError().GetExceptionName().c_str() + " " + result.GetError().GetMessage().c_str());
+    }
+
+    SetTags(client_, bucketName_, path_, tags_);
+  }
+};
+
+
+class DirectReader : public IStorage::IReader
+{
+protected:
+  std::shared_ptr<Aws::S3::S3Client>    client_;
+  std::string                           bucketName_;
+  std::list<std::string>                paths_;
+  std::string                           uuid_;
+
+public:
+  DirectReader(std::shared_ptr<Aws::S3::S3Client> client, const std::string& bucketName, const std::list<std::string>& paths, const char* uuid)
+    : client_(client),
+      bucketName_(bucketName),
+      paths_(paths),
+      uuid_(uuid)
+  {
+  }
+
+  virtual ~DirectReader()
+  {
+
+  }
+
+  virtual size_t GetSize() ORTHANC_OVERRIDE
+  {
+    std::string firstExceptionMessage;
+
+    for (auto& path: paths_)
+    {
+      try
+      {
+        return _GetSize(path);
+      }
+      catch (StoragePluginException& ex)
+      {
+        if (firstExceptionMessage.empty())
+        {
+          firstExceptionMessage = ex.what();
+        }
+        //ignore to retry
+      }
+    }
+    throw StoragePluginException(firstExceptionMessage);
+  }
+
+  virtual void ReadWhole(char* data, size_t size) ORTHANC_OVERRIDE
+  {
+    _Read(data, size, 0, false);
+  }
+
+  virtual void ReadRange(char* data, size_t size, size_t fromOffset) ORTHANC_OVERRIDE
+  {
+    _Read(data, size, fromOffset, true);
+  }
+
+private:
+
+  size_t _GetSize(const std::string& path)
+  {
+    Aws::S3::Model::ListObjectsRequest listObjectRequest;
+    listObjectRequest.SetBucket(bucketName_.c_str());
+    listObjectRequest.SetPrefix(path.c_str());
+
+    auto result = client_->ListObjects(listObjectRequest);
+
+    if (result.IsSuccess())
+    {
+      Aws::Vector<Aws::S3::Model::Object> objectList =
+          result.GetResult().GetContents();
+
+      if (objectList.size() == 1)
+      {
+        return objectList[0].GetSize();
+      }
+      else if (objectList.size() > 1)
+      {
+        throw StoragePluginException(std::string("error while reading file ") + path + ": multiple objet with same name !");
+      }
+      throw StoragePluginException(std::string("error while reading file ") + path + ": object not found !");
+    }
+    else
+    {
+      throw StoragePluginException(std::string("error while reading file ") + path + ": " + result.GetError().GetExceptionName().c_str() + " " + result.GetError().GetMessage().c_str());
+    }
+  }
+
+
+  void _Read(char* data, size_t size, size_t fromOffset, bool useRange)
+  {
+    std::string firstExceptionMessage;
+
+    for (auto& path: paths_)
+    {
+      try
+      {
+        return __Read(path, data, size, fromOffset, useRange);
+      }
+      catch (StoragePluginException& ex)
+      {
+        if (firstExceptionMessage.empty())
+        {
+          firstExceptionMessage = ex.what();
+        }
+        //ignore to retry
+      }
+    }
+    throw StoragePluginException(firstExceptionMessage);
+  }
+
+  void __Read(const std::string& path, char* data, size_t size, size_t fromOffset, bool useRange)
+  {
+    Aws::S3::Model::GetObjectRequest getObjectRequest;
+    getObjectRequest.SetBucket(bucketName_.c_str());
+    getObjectRequest.SetKey(path.c_str());
+
+    if (useRange)
+    {
+      // https://developer.mozilla.org/en-US/docs/Web/HTTP/Range_requests
+      std::string range = std::string("bytes=") + boost::lexical_cast<std::string>(fromOffset) + "-" + boost::lexical_cast<std::string>(fromOffset + size -1);
+      getObjectRequest.SetRange(range.c_str());
+    }
+
+    getObjectRequest.SetResponseStreamFactory(
+          [data, size]()
+    {
+      std::unique_ptr<Aws::StringStream>
+          istream(Aws::New<Aws::StringStream>(ALLOCATION_TAG));
+
+      istream->rdbuf()->pubsetbuf(static_cast<char*>(data),
+                                  size);
+
+      return istream.release();
+    });
+
+    // Get the object
+    auto result = client_->GetObject(getObjectRequest);
+    if (result.IsSuccess())
+    {
+    }
+    else
+    {
+      throw StoragePluginException(std::string("error while reading file ") + path + ": response code = " + boost::lexical_cast<std::string>((int)result.GetError().GetResponseCode()) + " " + result.GetError().GetExceptionName().c_str() + " " + result.GetError().GetMessage().c_str());
+    }
+  }
+
+};
+
+
+
+class TransferWriter : public IStorage::IWriter
+{
+  std::shared_ptr<Aws::S3::S3Client>                client_;
+  std::string                                       path_;
+  std::shared_ptr<Aws::Transfer::TransferManager>   transferManager_;
+  std::string                                       bucketName_;
+  Aws::S3::Model::StorageClass                      storageClass_;
+  std::map<std::string, std::string>                tags_;
+
+public:
+  TransferWriter(std::shared_ptr<Aws::S3::S3Client> client, std::shared_ptr<Aws::Transfer::TransferManager> transferManager, const std::string& bucketName, const std::string& path, Aws::S3::Model::StorageClass storageClass, const std::map<std::string, std::string>& tags)
+    : client_(client),
+      path_(path),
+      transferManager_(transferManager),
+      bucketName_(bucketName),
+      storageClass_(storageClass),
+      tags_(tags)
+  {
+  }
+
+  virtual ~TransferWriter()
+  {
+  }
+
+  virtual void Write(const char* data, size_t size) ORTHANC_OVERRIDE
+  {
+    boost::interprocess::bufferstream buffer(const_cast<char*>(static_cast<const char*>(data)), static_cast<size_t>(size));
+    std::shared_ptr<Aws::IOStream> body = Aws::MakeShared<Aws::IOStream>(ALLOCATION_TAG, buffer.rdbuf());
+
+    std::shared_ptr<Aws::Transfer::TransferHandle> transferHandle = transferManager_->UploadFile(body, bucketName_, path_.c_str(), "application/binary", Aws::Map<Aws::String, Aws::String>());
+    transferHandle->WaitUntilFinished();
+
+    if (transferHandle->GetStatus() != Aws::Transfer::TransferStatus::COMPLETED)
+    {
+      throw StoragePluginException(std::string("error while writing file ") + path_ + ": response code = " + boost::lexical_cast<std::string>(static_cast<int>(transferHandle->GetLastError().GetResponseCode())) + " " + transferHandle->GetLastError().GetMessage());
+    }
+
+    SetTags(client_, bucketName_, path_, tags_);
+  }
+};
+
+
+class TransferReader : public DirectReader
+{
+  std::shared_ptr<Aws::Transfer::TransferManager>  transferManager_;
+
+public:
+  TransferReader(std::shared_ptr<Aws::Transfer::TransferManager> transferManager, std::shared_ptr<Aws::S3::S3Client> client, const std::string& bucketName, const std::list<std::string>& paths, const char* uuid)
+    : DirectReader(client, bucketName, paths, uuid),
+      transferManager_(transferManager)
+  {
+  }
+
+  virtual ~TransferReader()
+  {
+
+  }
+
+  virtual void ReadWhole(char* data, size_t size) ORTHANC_OVERRIDE
+  {
+    std::string firstExceptionMessage;
+
+    for (auto& path: paths_)
+    {
+      try
+      {
+        // The local variable 'streamBuffer' is captured by reference in a lambda.
+        // It must persist until all downloading by the 'transfer_manager' is complete.
+        Aws::Utils::Stream::PreallocatedStreamBuf streamBuffer(reinterpret_cast<unsigned char*>(data), size);
+
+        std::shared_ptr<Aws::Transfer::TransferHandle> downloadHandler = transferManager_->DownloadFile(bucketName_, path, [&]() { //Define a lambda expression for the callback method parameter to stream back the data.
+                    return Aws::New<Aws::IOStream>(ALLOCATION_TAG, &streamBuffer);
+                });
+        
+        downloadHandler->WaitUntilFinished();
+
+        if (downloadHandler->GetStatus() == Aws::Transfer::TransferStatus::COMPLETED)
+        {
+          return;
+        }
+        else if (firstExceptionMessage.empty())
+        {
+          firstExceptionMessage = downloadHandler->GetLastError().GetMessage();
+        }
+    // getObjectRequest.SetResponseStreamFactory(
+    //       [data, size]()
+    // {
+    //   std::unique_ptr<Aws::StringStream>
+    //       istream(Aws::New<Aws::StringStream>(ALLOCATION_TAG));
+
+    //   istream->rdbuf()->pubsetbuf(static_cast<char*>(data),
+    //                               size);
+
+    //   return istream.release();
+    // });
+
+
+      }
+      catch (StoragePluginException& ex)
+      {
+        if (firstExceptionMessage.empty())
+        {
+          firstExceptionMessage = ex.what();
+        }
+        //ignore to retry
+      }
+    }
+    throw StoragePluginException(firstExceptionMessage);
+  }
+
+};
+
+
+
+
+const char* AwsS3StoragePluginFactory::GetStoragePluginName()
+{
+  return "AWS S3 Storage";
+}
+
+const char* AwsS3StoragePluginFactory::GetStorageDescription()
+{
+  return "Stores the Orthanc storage area in AWS S3";
+}
+
+static std::unique_ptr<Aws::Crt::ApiHandle>  api_;
+static std::unique_ptr<Aws::SDKOptions>  sdkOptions_;
+
+#include <stdarg.h>
+
+class AwsOrthancLogger : public Aws::Utils::Logging::LogSystemInterface
+{
+public:
+    virtual ~AwsOrthancLogger() {}
+
+    /**
+     * Gets the currently configured log level for this logger.
+     */
+    virtual Aws::Utils::Logging::LogLevel GetLogLevel() const ORTHANC_OVERRIDE
+    {
+      return Aws::Utils::Logging::LogLevel::Trace;
+    }
+    /**
+     * Does a printf style output to the output stream. Don't use this, it's unsafe. See LogStream
+     */
+    virtual void Log(Aws::Utils::Logging::LogLevel logLevel, const char* tag, const char* formatStr, ...) ORTHANC_OVERRIDE
+    {
+      Aws::StringStream ss;
+
+      va_list args;
+      va_start(args, formatStr);
+
+      va_list tmp_args; //unfortunately you cannot consume a va_list twice
+      va_copy(tmp_args, args); //so we have to copy it
+      #ifdef _WIN32
+          const int requiredLength = _vscprintf(formatStr, tmp_args) + 1;
+      #else
+          const int requiredLength = vsnprintf(nullptr, 0, formatStr, tmp_args) + 1;
+      #endif
+      va_end(tmp_args);
+
+      assert(requiredLength > 0);
+      std::string outputBuff;
+      outputBuff.resize(requiredLength);
+      #ifdef _WIN32
+          vsnprintf_s(&outputBuff[0], requiredLength, _TRUNCATE, formatStr, args);
+      #else
+          vsnprintf(&outputBuff[0], requiredLength, formatStr, args);
+      #endif // _WIN32
+
+      if (logLevel == Aws::Utils::Logging::LogLevel::Debug || logLevel == Aws::Utils::Logging::LogLevel::Trace)
+      {
+        LOG(INFO) << outputBuff;
+      }
+      else if (logLevel == Aws::Utils::Logging::LogLevel::Warn)
+      {
+        LOG(WARNING) << outputBuff;
+      }
+      else
+      {
+        LOG(ERROR) << outputBuff;
+      }
+
+      va_end(args);
+    }
+    /**
+    * Writes the stream to the output stream.
+    */
+    virtual void LogStream(Aws::Utils::Logging::LogLevel logLevel, const char* tag, const Aws::OStringStream &messageStream) ORTHANC_OVERRIDE
+    {
+      if (logLevel == Aws::Utils::Logging::LogLevel::Debug || logLevel == Aws::Utils::Logging::LogLevel::Trace)
+      {
+        LOG(INFO) << tag << messageStream.str();
+      }
+      else if (logLevel == Aws::Utils::Logging::LogLevel::Warn)
+      {
+        LOG(WARNING) << tag << messageStream.str();
+      }
+      else
+      {
+        LOG(ERROR) << tag << messageStream.str();
+      }
+
+    }
+    /**
+     * Writes any buffered messages to the underlying device if the logger supports buffering.
+     */
+    virtual void Flush() ORTHANC_OVERRIDE {}
+};
+
+IStorage* AwsS3StoragePluginFactory::CreateStorage(const std::string& nameForLogs, const OrthancPlugins::OrthancConfiguration& orthancConfig)
+{
+  if (sdkOptions_.get() != NULL)
+  {
+    throw Orthanc::OrthancException(Orthanc::ErrorCode_BadSequenceOfCalls, "Cannot initialize twice");
+  }
+
+  bool enableLegacyStorageStructure;
+  bool storageContainsUnknownFiles;
+
+  if (!orthancConfig.IsSection(GetConfigurationSectionName()))
+  {
+    LOG(WARNING) << GetStoragePluginName() << " plugin, section missing.  Plugin is not enabled.";
+    return nullptr;
+  }
+
+  OrthancPlugins::OrthancConfiguration pluginSection;
+  orthancConfig.GetSection(pluginSection, GetConfigurationSectionName());
+
+  if (!BaseStorage::ReadCommonConfiguration(enableLegacyStorageStructure, storageContainsUnknownFiles, pluginSection))
+  {
+    return nullptr;
+  }
+
+  std::string bucketName;
+  std::string region;
+  std::string accessKey;
+  std::string secretKey;
+
+  if (!pluginSection.LookupStringValue(bucketName, "BucketName"))
+  {
+    LOG(ERROR) << "AwsS3Storage/BucketName configuration missing.  Unable to initialize plugin";
+    return nullptr;
+  }
+
+  if (!pluginSection.LookupStringValue(region, "Region"))
+  {
+    LOG(ERROR) << "AwsS3Storage/Region configuration missing.  Unable to initialize plugin";
+    return nullptr;
+  }
+
+  const std::string endpoint = pluginSection.GetStringValue("Endpoint", "");
+  const unsigned int connectTimeout = pluginSection.GetUnsignedIntegerValue("ConnectTimeout", 30);  // till v 2.5.1
+  pluginSection.GetUnsignedIntegerValue("ConnectionTimeout", connectTimeout); // from v 2.5.1+, both ConnectTimeout and ConnectionTimeout are supported
+
+  const unsigned int requestTimeout = pluginSection.GetUnsignedIntegerValue("RequestTimeout", 1200);
+  const bool virtualAddressing = pluginSection.GetBooleanValue("VirtualAddressing", true);
+  const bool enableAwsSdkLogs = pluginSection.GetBooleanValue("EnableAwsSdkLogs", false);
+  const std::string caFile = orthancConfig.GetStringValue("HttpsCACertificates", "");
+
+
+  api_.reset(new Aws::Crt::ApiHandle);
+
+  sdkOptions_.reset(new Aws::SDKOptions);
+  sdkOptions_->cryptoOptions.initAndCleanupOpenSSL = false;  // Done by the Orthanc framework
+  sdkOptions_->httpOptions.initAndCleanupCurl = false;  // Done by the Orthanc framework
+
+  if (enableAwsSdkLogs)
+  {
+    // Set up logging
+    Aws::Utils::Logging::InitializeAWSLogging(Aws::MakeShared<AwsOrthancLogger>(ALLOCATION_TAG));
+    // strangely, this seems to disable logging !!!! sdkOptions_->loggingOptions.logLevel = Aws::Utils::Logging::LogLevel::Trace;
+  }
+
+  Aws::InitAPI(*sdkOptions_);
+
+
+  try
+  {
+    Aws::Client::ClientConfiguration configuration;
+
+    configuration.region = region.c_str();
+    configuration.scheme = Aws::Http::Scheme::HTTPS;
+    configuration.connectTimeoutMs = connectTimeout * 1000;
+    configuration.requestTimeoutMs  = requestTimeout * 1000;
+    configuration.httpRequestTimeoutMs = requestTimeout * 1000;
+
+    if (!endpoint.empty())
+    {
+      configuration.endpointOverride = endpoint.c_str();
+    }
+
+    if (!caFile.empty())
+    {
+      configuration.caFile = caFile;
+    }
+    
+    bool useTransferManager = false; // new in v 2.3.0
+    unsigned int transferPoolSize = 10;
+    unsigned int transferBufferSizeMB = 5;
+    std::string strStorageClass;
+    Aws::S3::Model::StorageClass storageClass = Aws::S3::Model::StorageClass::NOT_SET;
+
+    pluginSection.LookupBooleanValue(useTransferManager, "UseTransferManager");
+    pluginSection.LookupUnsignedIntegerValue(transferPoolSize, "TransferPoolSize");
+    pluginSection.LookupUnsignedIntegerValue(transferBufferSizeMB, "TransferBufferSize");
+    if (pluginSection.LookupStringValue(strStorageClass, "StorageClass"))
+    {
+      if (strStorageClass == "STANDARD")
+      {
+        storageClass = Aws::S3::Model::StorageClass::STANDARD;
+      }
+      else if (strStorageClass == "REDUCED_REDUNDANCY")
+      {
+        storageClass = Aws::S3::Model::StorageClass::REDUCED_REDUNDANCY;
+      }
+      else if (strStorageClass == "STANDARD_IA")
+      {
+        storageClass = Aws::S3::Model::StorageClass::STANDARD_IA;
+      }
+      else if (strStorageClass == "ONEZONE_IA")
+      {
+        storageClass = Aws::S3::Model::StorageClass::ONEZONE_IA;
+      }
+      else if (strStorageClass == "INTELLIGENT_TIERING")
+      {
+        storageClass = Aws::S3::Model::StorageClass::INTELLIGENT_TIERING;
+      }
+      else if (strStorageClass == "GLACIER")
+      {
+        storageClass = Aws::S3::Model::StorageClass::GLACIER;
+      }
+      else if (strStorageClass == "DEEP_ARCHIVE")
+      {
+        storageClass = Aws::S3::Model::StorageClass::DEEP_ARCHIVE;
+      }
+      else if (strStorageClass == "OUTPOSTS")
+      {
+        storageClass = Aws::S3::Model::StorageClass::OUTPOSTS;
+      }
+      else if (strStorageClass == "GLACIER_IR")
+      {
+        storageClass = Aws::S3::Model::StorageClass::GLACIER_IR;
+      }
+      else if (strStorageClass == "SNOW")
+      {
+        storageClass = Aws::S3::Model::StorageClass::SNOW;
+      }
+      else
+      {
+        LOG(ERROR) << "AWS S3 Storage plugin: unrecognized value for \"StorageClass\": " << strStorageClass;
+        return nullptr;
+      }
+    }
+
+    std::shared_ptr<Aws::S3::S3Client> client;
+
+    if (pluginSection.LookupStringValue(accessKey, "AccessKey") && pluginSection.LookupStringValue(secretKey, "SecretKey"))
+    {
+      LOG(INFO) << "AWS S3 Storage: using credentials from the configuration file";
+      Aws::Auth::AWSCredentials credentials(accessKey.c_str(), secretKey.c_str());
+      
+      client = Aws::MakeShared<Aws::S3::S3Client>(ALLOCATION_TAG, credentials, configuration, Aws::Client::AWSAuthV4Signer::PayloadSigningPolicy::Never, virtualAddressing);
+    } 
+    else
+    {
+      // when using default credentials, credentials are not checked at startup but only the first time you try to access the bucket !
+      LOG(INFO) << "AWS S3 Storage: using default credentials provider";
+      client = Aws::MakeShared<Aws::S3::S3Client>(ALLOCATION_TAG, configuration, Aws::Client::AWSAuthV4Signer::PayloadSigningPolicy::Never, virtualAddressing);
+    }  
+
+    std::map<std::string, std::string> tags;
+    pluginSection.GetDictionary(tags, "Tags");
+
+    LOG(INFO) << "AWS S3 storage initialized";
+
+    return new AwsS3StoragePlugin(nameForLogs, client, bucketName, enableLegacyStorageStructure, storageContainsUnknownFiles, useTransferManager, transferPoolSize, transferBufferSizeMB, storageClass, tags);
+  }
+  catch (const std::exception& e)
+  {
+    Aws::ShutdownAPI(*sdkOptions_);
+    LOG(ERROR) << "AWS S3 Storage plugin: failed to initialize plugin: " << e.what();
+    return nullptr;
+  }
+}
+
+
+AwsS3StoragePlugin::~AwsS3StoragePlugin()
+{
+  assert(sdkOptions_.get() != NULL);
+  Aws::ShutdownAPI(*sdkOptions_);
+  api_.reset();
+  sdkOptions_.reset();
+}
+
+
+AwsS3StoragePlugin::AwsS3StoragePlugin(const std::string& nameForLogs, 
+                                       std::shared_ptr<Aws::S3::S3Client> client, 
+                                       const std::string& bucketName, 
+                                       bool enableLegacyStorageStructure, 
+                                       bool storageContainsUnknownFiles, 
+                                       bool useTransferManager,
+                                       unsigned int transferThreadPoolSize,
+                                       unsigned int transferBufferSizeMB,
+                                       Aws::S3::Model::StorageClass storageClass,
+                                       const std::map<std::string, std::string>& tags)
+  : BaseStorage(nameForLogs, enableLegacyStorageStructure),
+    bucketName_(bucketName),
+    storageContainsUnknownFiles_(storageContainsUnknownFiles),
+    useTransferManager_(useTransferManager),
+    client_(client),
+    storageClass_(storageClass),
+    tags_(tags)
+{
+  if (useTransferManager_)
+  {
+    executor_ = Aws::MakeShared<Aws::Utils::Threading::PooledThreadExecutor>(ALLOCATION_TAG, transferThreadPoolSize);
+    Aws::Transfer::TransferManagerConfiguration transferConfig(executor_.get());
+    transferConfig.s3Client = client_;
+    transferConfig.bufferSize = static_cast<uint64_t>(transferBufferSizeMB) * 1024 * 1024;
+    transferConfig.transferBufferMaxHeapSize = static_cast<uint64_t>(transferBufferSizeMB) * 1024 * 1024 * transferThreadPoolSize;
+    if (storageClass_ != Aws::S3::Model::StorageClass::NOT_SET)
+    {
+      transferConfig.putObjectTemplate.SetStorageClass(storageClass_);
+    }
+
+    transferManager_ = Aws::Transfer::TransferManager::Create(transferConfig);
+  }
+}
+
+IStorage::IWriter* AwsS3StoragePlugin::GetWriterForObject(const char* uuid, OrthancPluginContentType type, bool encryptionEnabled)
+{
+  if (useTransferManager_)
+  {
+    return new TransferWriter(client_, transferManager_, bucketName_, GetPath(uuid, type, encryptionEnabled), storageClass_, tags_);
+  }
+  else
+  {
+    return new DirectWriter(client_, bucketName_, GetPath(uuid, type, encryptionEnabled), storageClass_, tags_);
+  }
+}
+
+IStorage::IReader* AwsS3StoragePlugin::GetReaderForObject(const char* uuid, OrthancPluginContentType type, bool encryptionEnabled)
+{
+  std::list<std::string> paths;
+  paths.push_back(GetPath(uuid, type, encryptionEnabled, false));
+  if (storageContainsUnknownFiles_)
+  {
+    paths.push_back(GetPath(uuid, type, encryptionEnabled, true));
+  }
+
+  if (useTransferManager_)
+  {
+    return new TransferReader(transferManager_, client_, bucketName_, paths, uuid);
+  }
+  else
+  {
+    return new DirectReader(client_, bucketName_, paths, uuid);
+  }
+}
+
+void AwsS3StoragePlugin::DeleteObject(const char* uuid, OrthancPluginContentType type, bool encryptionEnabled)
+{
+  std::string firstExceptionMessage;
+
+  std::list<std::string> paths;
+  paths.push_back(GetPath(uuid, type, encryptionEnabled, false));
+  if (storageContainsUnknownFiles_)
+  {
+    paths.push_back(GetPath(uuid, type, encryptionEnabled, true));
+  }
+
+  // DeleteObject succeeds even if the file does not exist -> we need to try to delete every path
+  for (auto& path: paths)
+  {
+    Aws::S3::Model::DeleteObjectRequest deleteObjectRequest;
+    deleteObjectRequest.SetBucket(bucketName_.c_str());
+    deleteObjectRequest.SetKey(path.c_str());
+
+    auto result = client_->DeleteObject(deleteObjectRequest);
+
+    if (!result.IsSuccess() && firstExceptionMessage.empty())
+    {
+      firstExceptionMessage = std::string("error while deleting file ") + path + ": response code = " + boost::lexical_cast<std::string>((int)result.GetError().GetResponseCode()) + " " + result.GetError().GetExceptionName().c_str() + " " + result.GetError().GetMessage().c_str();
+    }
+  }
+
+  if (!firstExceptionMessage.empty())
+  {
+    throw StoragePluginException(firstExceptionMessage);
+  }
+}
+
+// Custom path support methods
+
+IStorage::IWriter* AwsS3StoragePlugin::GetWriterForObject(const char* uuid, OrthancPluginContentType type, bool encryptionEnabled, const std::string& customPath)
+{
+  std::string path = customPath.empty() ? GetPath(uuid, type, encryptionEnabled) : GetPathWithCustom(uuid, type, encryptionEnabled, customPath);
+
+  if (useTransferManager_)
+  {
+    return new TransferWriter(client_, transferManager_, bucketName_, path, storageClass_, tags_);
+  }
+  else
+  {
+    return new DirectWriter(client_, bucketName_, path, storageClass_, tags_);
+  }
+}
+
+IStorage::IReader* AwsS3StoragePlugin::GetReaderForObject(const char* uuid, OrthancPluginContentType type, bool encryptionEnabled, const std::string& customPath)
+{
+  std::list<std::string> paths;
+
+  if (!customPath.empty())
+  {
+    // Use custom path as primary
+    paths.push_back(GetPathWithCustom(uuid, type, encryptionEnabled, customPath));
+  }
+  else
+  {
+    // Fall back to UUID-based paths
+    paths.push_back(GetPath(uuid, type, encryptionEnabled, false));
+    if (storageContainsUnknownFiles_)
+    {
+      paths.push_back(GetPath(uuid, type, encryptionEnabled, true));
+    }
+  }
+
+  if (useTransferManager_)
+  {
+    return new TransferReader(transferManager_, client_, bucketName_, paths, uuid);
+  }
+  else
+  {
+    return new DirectReader(client_, bucketName_, paths, uuid);
+  }
+}
+
+void AwsS3StoragePlugin::DeleteObject(const char* uuid, OrthancPluginContentType type, bool encryptionEnabled, const std::string& customPath)
+{
+  std::string path = customPath.empty() ? GetPath(uuid, type, encryptionEnabled) : GetPathWithCustom(uuid, type, encryptionEnabled, customPath);
+
+  Aws::S3::Model::DeleteObjectRequest deleteObjectRequest;
+  deleteObjectRequest.SetBucket(bucketName_.c_str());
+  deleteObjectRequest.SetKey(path.c_str());
+
+  auto result = client_->DeleteObject(deleteObjectRequest);
+
+  if (!result.IsSuccess())
+  {
+    throw StoragePluginException(std::string("error while deleting file ") + path + ": response code = " + boost::lexical_cast<std::string>((int)result.GetError().GetResponseCode()) + " " + result.GetError().GetExceptionName().c_str() + " " + result.GetError().GetMessage().c_str());
+  }
+}

--- a/Plugins/orthanc-s3-namingscheme/Common/BaseStorage.cpp
+++ b/Plugins/orthanc-s3-namingscheme/Common/BaseStorage.cpp
@@ -1,0 +1,116 @@
+/**
+ * Cloud storage plugins for Orthanc
+ * Copyright (C) 2020-2023 Osimis S.A., Belgium
+ * Copyright (C) 2024-2026 Orthanc Team SRL, Belgium
+ * Copyright (C) 2021-2026 Sebastien Jodogne, ICTEAM UCLouvain, Belgium
+ *
+ * This program is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ **/
+
+
+#include "BaseStorage.h"
+
+#include <Logging.h>
+
+#include <boost/filesystem/fstream.hpp>
+
+boost::filesystem::path BaseStorage::GetOrthancFileSystemPath(const std::string& uuid, const std::string& fileSystemRootPath)
+{
+  boost::filesystem::path path = fileSystemRootPath;
+
+  path /= std::string(&uuid[0], &uuid[2]);
+  path /= std::string(&uuid[2], &uuid[4]);
+  path /= uuid;
+
+  path.make_preferred();
+
+  return path;
+}
+
+
+std::string BaseStorage::GetPath(const char* uuid, OrthancPluginContentType type, bool encryptionEnabled, bool useAlternateExtension)
+{
+  if (enableLegacyStorageStructure_)
+  {
+    return GetOrthancFileSystemPath(uuid, rootPath_).string();
+  }
+  else
+  {
+    boost::filesystem::path path = rootPath_;
+    std::string filename = std::string(uuid);
+
+    if (type == OrthancPluginContentType_Dicom)
+    {
+      filename += ".dcm";
+    }
+    else if (type == OrthancPluginContentType_DicomAsJson)
+    {
+      filename += ".json";
+    }
+    else if (type == OrthancPluginContentType_DicomUntilPixelData && !useAlternateExtension)  // for some time, header files were saved with .unk (happened with S3 storage plugin between version 1.2.0 and 1.3.0 - 21.5.1 and 21.6.2)
+    {
+      filename += ".dcm.head";
+    }
+    else
+    {
+      filename += ".unk";
+    }
+
+    if (encryptionEnabled)
+    {
+      filename += ".enc";
+    }
+    path /= filename;
+
+    return path.string();
+  }
+}
+
+std::string BaseStorage::GetPathWithCustom(const char* uuid, OrthancPluginContentType type, bool encryptionEnabled, const std::string& customPath)
+{
+  if (!customPath.empty())
+  {
+    // Use the custom path (already includes rootPath from PathGenerator)
+    boost::filesystem::path path = rootPath_;
+    path /= customPath;
+    return path.string();
+  }
+  else
+  {
+    // Fall back to UUID-based path
+    return GetPath(uuid, type, encryptionEnabled, false);
+  }
+}
+
+bool BaseStorage::ReadCommonConfiguration(bool& enableLegacyStorageStructure, bool& storageContainsUnknownFiles, const OrthancPlugins::OrthancConfiguration& pluginSection)
+{
+  std::string storageStructure = pluginSection.GetStringValue("StorageStructure", "flat");
+  if (storageStructure == "flat")
+  {
+    enableLegacyStorageStructure = false;
+  }
+  else
+  {
+    enableLegacyStorageStructure = true;
+    if (storageStructure != "legacy")
+    {
+      LOG(ERROR) << "ObjectStorage/StorageStructure configuration invalid value: " << storageStructure << ", allowed values are 'flat' and 'legacy'";
+      return false;
+    }
+  }
+
+  storageContainsUnknownFiles = pluginSection.GetBooleanValue("EnableLegacyUnknownFiles", false);
+
+  return true;
+}

--- a/Plugins/orthanc-s3-namingscheme/Common/BaseStorage.h
+++ b/Plugins/orthanc-s3-namingscheme/Common/BaseStorage.h
@@ -1,0 +1,64 @@
+/**
+ * Cloud storage plugins for Orthanc
+ * Copyright (C) 2020-2023 Osimis S.A., Belgium
+ * Copyright (C) 2024-2026 Orthanc Team SRL, Belgium
+ * Copyright (C) 2021-2026 Sebastien Jodogne, ICTEAM UCLouvain, Belgium
+ *
+ * This program is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ **/
+
+
+#pragma once
+
+#include "IStorage.h"
+
+#include <Compatibility.h>
+
+#include <boost/filesystem.hpp>
+
+namespace fs = boost::filesystem;
+
+class BaseStorage : public IStorage
+{
+  bool        enableLegacyStorageStructure_;
+  std::string rootPath_;
+
+protected:
+
+  BaseStorage(const std::string& nameForLogs, bool enableLegacyStorageStructure):
+    IStorage(nameForLogs),
+    enableLegacyStorageStructure_(enableLegacyStorageStructure)
+  {}
+
+  std::string GetPath(const char* uuid, OrthancPluginContentType type, bool encryptionEnabled, bool useAlternateExtension = false);
+
+  // Get path - uses customPath if provided, otherwise generates from UUID
+  std::string GetPathWithCustom(const char* uuid, OrthancPluginContentType type, bool encryptionEnabled, const std::string& customPath);
+
+public:
+  virtual void SetRootPath(const std::string& rootPath) ORTHANC_OVERRIDE
+  {
+    rootPath_ = rootPath;
+  }
+
+  const std::string& GetRootPath() const
+  {
+    return rootPath_;
+  }
+
+  static std::string GetPath(const char* uuid, OrthancPluginContentType type, bool encryptionEnabled, bool legacyFileStructure, const std::string& rootFolder);
+  static fs::path GetOrthancFileSystemPath(const std::string& uuid, const std::string& fileSystemRootPath);
+
+  static bool ReadCommonConfiguration(bool& enableLegacyStorageStructure, bool& storageContainsUnknownFiles, const OrthancPlugins::OrthancConfiguration& pluginSection);
+};

--- a/Plugins/orthanc-s3-namingscheme/Common/FileSystemStorage.cpp
+++ b/Plugins/orthanc-s3-namingscheme/Common/FileSystemStorage.cpp
@@ -1,0 +1,250 @@
+/**
+ * Cloud storage plugins for Orthanc
+ * Copyright (C) 2020-2023 Osimis S.A., Belgium
+ * Copyright (C) 2024-2026 Orthanc Team SRL, Belgium
+ * Copyright (C) 2021-2026 Sebastien Jodogne, ICTEAM UCLouvain, Belgium
+ *
+ * This program is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ **/
+
+#include "FileSystemStorage.h"
+#include "BaseStorage.h"
+
+#include <Logging.h>
+#include <SystemToolbox.h>
+
+#include <boost/filesystem.hpp>
+#include <boost/filesystem/fstream.hpp>
+
+namespace fs = boost::filesystem;
+
+void FileSystemStoragePlugin::FileSystemWriter::Write(const char* data, size_t size)
+{
+  Orthanc::SystemToolbox::MakeDirectory(path_.parent_path().string());
+
+  Orthanc::SystemToolbox::WriteFile(reinterpret_cast<const void*>(data), size, path_.string(), fsync_);
+}
+
+size_t FileSystemStoragePlugin::FileSystemReader::GetSize()
+{
+  if (!Orthanc::SystemToolbox::IsRegularFile(path_.string()))
+  {
+    throw StoragePluginException(std::string("The path does not point to a regular file: ") + path_.string());
+  }
+
+  try
+  {
+    fs::ifstream f;
+    f.open(path_.string(), std::ifstream::in | std::ifstream::binary);
+    if (!f.good())
+    {
+      throw StoragePluginException(std::string("The path does not point to a regular file: ") + path_.string());
+    }
+
+    f.seekg(0, std::ios::end);
+    std::streamsize fileSize = f.tellg();
+    f.seekg(0, std::ios::beg);
+
+    f.close();
+
+    return fileSize;
+  }
+  catch (...)
+  {
+    throw StoragePluginException(std::string("Unexpected error while reading: ") + path_.string());
+  }
+
+}
+
+void FileSystemStoragePlugin::FileSystemReader::ReadWhole(char* data, size_t size)
+{
+  ReadRange(data, size, 0);
+}
+
+void FileSystemStoragePlugin::FileSystemReader::ReadRange(char* data, size_t size, size_t fromOffset)
+{
+  if (!Orthanc::SystemToolbox::IsRegularFile(path_.string()))
+  {
+    throw StoragePluginException(std::string("The path does not point to a regular file: ") + path_.string());
+  }
+
+  try
+  {
+    fs::ifstream f;
+    f.open(path_.string(), std::ifstream::in | std::ifstream::binary);
+    if (!f.good())
+    {
+      throw StoragePluginException(std::string("The path does not point to a regular file: ") + path_.string());
+    }
+
+    f.seekg(fromOffset, std::ios::beg);
+
+    f.read(reinterpret_cast<char*>(data), size);
+
+    f.close();
+  }
+  catch (...)
+  {
+    throw StoragePluginException(std::string("Unexpected error while reading: ") + path_.string());
+  }
+}
+
+
+
+IStorage::IWriter* FileSystemStoragePlugin::GetWriterForObject(const char* uuid, OrthancPluginContentType type, bool encryptionEnabled)
+{
+  return new FileSystemWriter(BaseStorage::GetOrthancFileSystemPath(uuid, fileSystemRootPath_), fsync_);
+}
+
+IStorage::IReader* FileSystemStoragePlugin::GetReaderForObject(const char* uuid, OrthancPluginContentType type, bool encryptionEnabled)
+{
+  return new FileSystemReader(BaseStorage::GetOrthancFileSystemPath(uuid, fileSystemRootPath_));
+}
+
+void FileSystemStoragePlugin::DeleteObject(const char* uuid, OrthancPluginContentType type, bool encryptionEnabled)
+{
+  try
+  {
+    namespace fs = boost::filesystem;
+
+    fs::path path = BaseStorage::GetOrthancFileSystemPath(uuid, fileSystemRootPath_);
+
+    try
+    {
+      fs::remove(path.string());
+    }
+    catch (...)
+    {
+      // Ignore the error
+    }
+
+    // Remove the two parent directories, ignoring the error code if
+    // these directories are not empty
+
+    try
+    {
+      boost::system::error_code err;
+      fs::remove(path.parent_path().string(), err);
+      fs::remove(path.parent_path().parent_path().string(), err);
+    }
+    catch (...)
+    {
+      // Ignore the error
+    }
+  }
+  catch(Orthanc::OrthancException& e)
+  {
+    LOG(ERROR) << GetNameForLogs() << ": error while deleting object " << uuid << ": " << e.What();
+  }
+
+}
+
+bool FileSystemStoragePlugin::FileExists(const std::string& uuid, OrthancPluginContentType type, bool encryptionEnabled)
+{
+  namespace fs = boost::filesystem;
+
+  fs::path path = BaseStorage::GetOrthancFileSystemPath(uuid, fileSystemRootPath_);
+
+  return Orthanc::SystemToolbox::IsRegularFile(path.string());
+}
+
+// Custom path support implementations
+
+IStorage::IWriter* FileSystemStoragePlugin::GetWriterForObject(const char* uuid, OrthancPluginContentType type, bool encryptionEnabled, const std::string& customPath)
+{
+  if (!customPath.empty())
+  {
+    fs::path path = fileSystemRootPath_;
+    path /= customPath;
+    LOG(INFO) << GetNameForLogs() << ": Writing to custom path: " << path.string();
+    return new FileSystemWriter(path, fsync_);
+  }
+  else
+  {
+    return GetWriterForObject(uuid, type, encryptionEnabled);
+  }
+}
+
+IStorage::IReader* FileSystemStoragePlugin::GetReaderForObject(const char* uuid, OrthancPluginContentType type, bool encryptionEnabled, const std::string& customPath)
+{
+  if (!customPath.empty())
+  {
+    fs::path path = fileSystemRootPath_;
+    path /= customPath;
+    LOG(INFO) << GetNameForLogs() << ": Reading from custom path: " << path.string();
+    return new FileSystemReader(path);
+  }
+  else
+  {
+    return GetReaderForObject(uuid, type, encryptionEnabled);
+  }
+}
+
+void FileSystemStoragePlugin::DeleteObject(const char* uuid, OrthancPluginContentType type, bool encryptionEnabled, const std::string& customPath)
+{
+  try
+  {
+    namespace fs = boost::filesystem;
+
+    fs::path path;
+    if (!customPath.empty())
+    {
+      path = fileSystemRootPath_;
+      path /= customPath;
+      LOG(INFO) << GetNameForLogs() << ": Deleting from custom path: " << path.string();
+    }
+    else
+    {
+      path = BaseStorage::GetOrthancFileSystemPath(uuid, fileSystemRootPath_);
+    }
+
+    try
+    {
+      fs::remove(path.string());
+    }
+    catch (...)
+    {
+      // Ignore the error
+    }
+
+    // Remove empty parent directories
+    try
+    {
+      boost::system::error_code err;
+      fs::path parent = path.parent_path();
+
+      // Remove empty directories up the tree (up to 5 levels for custom paths)
+      for (int i = 0; i < 5 && !parent.empty() && parent != fileSystemRootPath_; ++i)
+      {
+        if (fs::is_empty(parent))
+        {
+          fs::remove(parent, err);
+          parent = parent.parent_path();
+        }
+        else
+        {
+          break;
+        }
+      }
+    }
+    catch (...)
+    {
+      // Ignore the error
+    }
+  }
+  catch(Orthanc::OrthancException& e)
+  {
+    LOG(ERROR) << GetNameForLogs() << ": error while deleting object " << uuid << ": " << e.What();
+  }
+}

--- a/Plugins/orthanc-s3-namingscheme/Common/FileSystemStorage.h
+++ b/Plugins/orthanc-s3-namingscheme/Common/FileSystemStorage.h
@@ -1,0 +1,83 @@
+/**
+ * Cloud storage plugins for Orthanc
+ * Copyright (C) 2020-2023 Osimis S.A., Belgium
+ * Copyright (C) 2024-2026 Orthanc Team SRL, Belgium
+ * Copyright (C) 2021-2026 Sebastien Jodogne, ICTEAM UCLouvain, Belgium
+ *
+ * This program is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ **/
+
+
+#pragma once
+
+#include "IStorage.h"
+#include <boost/filesystem.hpp>
+
+namespace fs = boost::filesystem;
+
+
+class FileSystemStoragePlugin: public IStorage
+{
+public:
+  class FileSystemWriter: public IStorage::IWriter
+  {
+    const fs::path path_;
+    bool fsync_;
+  public:
+    FileSystemWriter(const fs::path& path, bool fsync)
+    : path_(path),
+      fsync_(fsync)
+    {}
+
+    virtual ~FileSystemWriter() {}
+    virtual void Write(const char* data, size_t size) ORTHANC_OVERRIDE;
+  };
+
+  class FileSystemReader: public IStorage::IReader
+  {
+    const fs::path path_;
+  public:
+    explicit FileSystemReader(const fs::path& path)
+    : path_(path)
+    {}
+
+    virtual ~FileSystemReader() {}
+    virtual size_t GetSize() ORTHANC_OVERRIDE;
+    virtual void ReadWhole(char* data, size_t size) ORTHANC_OVERRIDE;
+    virtual void ReadRange(char* data, size_t size, size_t fromOffset) ORTHANC_OVERRIDE;
+  };
+
+  std::string fileSystemRootPath_;
+  bool fsync_;
+public:
+  FileSystemStoragePlugin(const std::string& nameForLogs, const std::string& fileSystemRootPath, bool fsync)
+  : IStorage(nameForLogs),
+    fileSystemRootPath_(fileSystemRootPath),
+    fsync_(fsync)
+  {}
+
+  virtual void SetRootPath(const std::string& rootPath) ORTHANC_OVERRIDE {}
+
+  virtual IStorage::IWriter* GetWriterForObject(const char* uuid, OrthancPluginContentType type, bool encryptionEnabled) ORTHANC_OVERRIDE;
+  virtual IStorage::IReader* GetReaderForObject(const char* uuid, OrthancPluginContentType type, bool encryptionEnabled) ORTHANC_OVERRIDE;
+  virtual void DeleteObject(const char* uuid, OrthancPluginContentType type, bool encryptionEnabled) ORTHANC_OVERRIDE;
+
+  // Custom path support overrides
+  virtual IStorage::IWriter* GetWriterForObject(const char* uuid, OrthancPluginContentType type, bool encryptionEnabled, const std::string& customPath) ORTHANC_OVERRIDE;
+  virtual IStorage::IReader* GetReaderForObject(const char* uuid, OrthancPluginContentType type, bool encryptionEnabled, const std::string& customPath) ORTHANC_OVERRIDE;
+  virtual void DeleteObject(const char* uuid, OrthancPluginContentType type, bool encryptionEnabled, const std::string& customPath) ORTHANC_OVERRIDE;
+
+  virtual bool HasFileExists() ORTHANC_OVERRIDE {return true;};
+  virtual bool FileExists(const std::string& uuid, OrthancPluginContentType type, bool encryptionEnabled) ORTHANC_OVERRIDE;
+};

--- a/Plugins/orthanc-s3-namingscheme/Common/IStorage.h
+++ b/Plugins/orthanc-s3-namingscheme/Common/IStorage.h
@@ -1,0 +1,112 @@
+/**
+ * Cloud storage plugins for Orthanc
+ * Copyright (C) 2020-2023 Osimis S.A., Belgium
+ * Copyright (C) 2024-2026 Orthanc Team SRL, Belgium
+ * Copyright (C) 2021-2026 Sebastien Jodogne, ICTEAM UCLouvain, Belgium
+ *
+ * This program is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ **/
+
+
+#pragma once
+
+#include <orthanc/OrthancCPlugin.h>
+#include <OrthancPluginCppWrapper.h>
+
+class StoragePluginException : public std::runtime_error
+{
+public:
+  explicit StoragePluginException(const std::string& what)
+    : std::runtime_error(what)
+  {
+  }
+};
+
+
+
+
+// each "plugin" must also provide these global methods
+//class XXXStoragePluginFactory
+//{
+//public:
+//  const char* GetStoragePluginName();
+//  IStorage* CreateStorage(const OrthancPlugins::OrthancConfiguration& orthancConfig);
+//};
+
+class IStorage : public boost::noncopyable
+{
+public:
+  class IWriter
+  {
+  public:
+    IWriter()
+    {}
+
+    virtual ~IWriter() {}
+    virtual void Write(const char* data, size_t size) = 0;
+  };
+
+  class IReader
+  {
+  public:
+    IReader()
+    {}
+
+    virtual ~IReader() {}
+    virtual size_t GetSize() = 0;
+    virtual void ReadWhole(char* data, size_t size) = 0;
+    virtual void ReadRange(char* data, size_t size, size_t fromOffset) = 0;
+  };
+
+  std::string nameForLogs_;
+public:
+  IStorage(const std::string& nameForLogs):
+    nameForLogs_(nameForLogs)
+  {}
+
+  virtual ~IStorage()
+  {
+  }
+
+  virtual void SetRootPath(const std::string& rootPath) = 0;
+
+  // Legacy methods (for backward compatibility)
+  virtual IWriter* GetWriterForObject(const char* uuid, OrthancPluginContentType type, bool encryptionEnabled) = 0;
+  virtual IReader* GetReaderForObject(const char* uuid, OrthancPluginContentType type, bool encryptionEnabled) = 0;
+  virtual void DeleteObject(const char* uuid, OrthancPluginContentType type, bool encryptionEnabled) = 0;
+
+  // New methods with custom path support
+  virtual IWriter* GetWriterForObject(const char* uuid, OrthancPluginContentType type, bool encryptionEnabled, const std::string& customPath)
+  {
+    // Default implementation ignores customPath for backward compatibility
+    return GetWriterForObject(uuid, type, encryptionEnabled);
+  }
+
+  virtual IReader* GetReaderForObject(const char* uuid, OrthancPluginContentType type, bool encryptionEnabled, const std::string& customPath)
+  {
+    // Default implementation ignores customPath for backward compatibility
+    return GetReaderForObject(uuid, type, encryptionEnabled);
+  }
+
+  virtual void DeleteObject(const char* uuid, OrthancPluginContentType type, bool encryptionEnabled, const std::string& customPath)
+  {
+    // Default implementation ignores customPath for backward compatibility
+    DeleteObject(uuid, type, encryptionEnabled);
+  }
+
+  const std::string& GetNameForLogs() {return nameForLogs_;}
+
+  virtual bool HasFileExists() = 0;
+  virtual bool FileExists(const std::string& uuid, OrthancPluginContentType type, bool encryptionEnabled) {return false;}
+};

--- a/Plugins/orthanc-s3-namingscheme/Common/PathGenerator.cpp
+++ b/Plugins/orthanc-s3-namingscheme/Common/PathGenerator.cpp
@@ -1,0 +1,311 @@
+/**
+ * Cloud storage plugins for Orthanc
+ * Copyright (C) 2020-2023 Osimis S.A., Belgium
+ * Copyright (C) 2024-2026 Orthanc Team SRL, Belgium
+ * Copyright (C) 2021-2026 Sebastien Jodogne, ICTEAM UCLouvain, Belgium
+ *
+ * This program is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ **/
+
+#include "PathGenerator.h"
+
+#include <Logging.h>
+#include <OrthancException.h>
+#include <Toolbox.h>
+
+#include <boost/algorithm/string/replace.hpp>
+#include <boost/lexical_cast.hpp>
+#include <sstream>
+#include <iomanip>
+#include <regex>
+#include <mutex>
+
+static std::string namingScheme_;
+static size_t maxPathLength_ = 0;  // 0 means no limit
+
+// DICOM tag keyword to hex mapping
+static std::map<std::string, std::string> dicomTagKeywords_;
+static std::once_flag dicomTagKeywordsInitFlag_;
+
+static void InitializeTagKeywords()
+{
+  std::call_once(dicomTagKeywordsInitFlag_, []() {
+    // Patient level
+    dicomTagKeywords_["PatientID"] = "0010,0020";
+    dicomTagKeywords_["PatientName"] = "0010,0010";
+    dicomTagKeywords_["PatientBirthDate"] = "0010,0030";
+    dicomTagKeywords_["PatientSex"] = "0010,0040";
+    dicomTagKeywords_["ResponsibleOrganization"] = "0010,2299";
+
+    // Study level
+    dicomTagKeywords_["StudyInstanceUID"] = "0020,000D";
+    dicomTagKeywords_["StudyDate"] = "0008,0020";
+    dicomTagKeywords_["StudyTime"] = "0008,0030";
+    dicomTagKeywords_["StudyID"] = "0020,0010";
+    dicomTagKeywords_["StudyDescription"] = "0008,1030";
+    dicomTagKeywords_["AccessionNumber"] = "0008,0050";
+    dicomTagKeywords_["ReferringPhysicianName"] = "0008,0090";
+
+    // Series level
+    dicomTagKeywords_["SeriesInstanceUID"] = "0020,000E";
+    dicomTagKeywords_["SeriesDate"] = "0008,0021";
+    dicomTagKeywords_["SeriesDescription"] = "0008,103E";
+    dicomTagKeywords_["SeriesNumber"] = "0020,0011";
+    dicomTagKeywords_["Modality"] = "0008,0060";
+
+    // Instance level
+    dicomTagKeywords_["SOPInstanceUID"] = "0008,0018";
+    dicomTagKeywords_["SOPClassUID"] = "0008,0016";
+    dicomTagKeywords_["InstanceNumber"] = "0020,0013";
+  });
+}
+
+static std::string GetTagValueFromJson(const Json::Value& tags, const std::string& tagKey)
+{
+  // First try direct access (simplified JSON uses keywords)
+  if (tags.isMember(tagKey) && tags[tagKey].isString())
+  {
+    return tags[tagKey].asString();
+  }
+
+  // If it's an integer value (like InstanceNumber), convert to string
+  if (tags.isMember(tagKey) && tags[tagKey].isInt())
+  {
+    return boost::lexical_cast<std::string>(tags[tagKey].asInt());
+  }
+
+  return "";
+}
+
+static std::string GetTagValueByHex(const Json::Value& tags, const std::string& hexTag)
+{
+  // hexTag format: "0010,2299" or "0010,0020"
+  // Simplified JSON uses keyword names, so we need to reverse lookup
+  InitializeTagKeywords();
+
+  for (const auto& pair : dicomTagKeywords_)
+  {
+    if (pair.second == hexTag)
+    {
+      return GetTagValueFromJson(tags, pair.first);
+    }
+  }
+
+  return "";
+}
+
+static std::string SanitizeForPath(const std::string& value)
+{
+  // Remove or replace characters that are invalid in paths/S3 keys
+  std::string result;
+  result.reserve(value.size());
+
+  for (char c : value)
+  {
+    if (c == '/' || c == '\\' || c == ':' || c == '*' ||
+        c == '?' || c == '"' || c == '<' || c == '>' || c == '|')
+    {
+      result += '_';
+    }
+    else if (c >= 32 && c < 127)  // Only printable ASCII
+    {
+      result += c;
+    }
+    else
+    {
+      result += '_';
+    }
+  }
+
+  // Trim trailing spaces and dots (problematic on Windows/some systems)
+  while (!result.empty() && (result.back() == ' ' || result.back() == '.'))
+  {
+    result.pop_back();
+  }
+
+  return result.empty() ? "UNKNOWN" : result;
+}
+
+void PathGenerator::SetNamingScheme(const std::string& namingScheme)
+{
+  namingScheme_ = namingScheme;
+
+  if (!namingScheme_.empty() && namingScheme_ != "flat" && namingScheme_ != "legacy")
+  {
+    LOG(WARNING) << "PathGenerator: Using custom naming scheme: " << namingScheme_;
+
+    // Validate that scheme contains UUID or SOPInstanceUID for uniqueness
+    if (namingScheme_.find("{UUID}") == std::string::npos &&
+        namingScheme_.find("{SOPInstanceUID}") == std::string::npos)
+    {
+      LOG(WARNING) << "PathGenerator: Custom naming scheme should contain {UUID} or {SOPInstanceUID} for uniqueness";
+    }
+  }
+}
+
+void PathGenerator::SetMaxPathLength(size_t maxLength)
+{
+  maxPathLength_ = maxLength;
+
+  if (maxLength > 0)
+  {
+    LOG(WARNING) << "PathGenerator: Maximum path length set to " << maxLength << " bytes";
+  }
+}
+
+bool PathGenerator::IsDefaultNamingScheme()
+{
+  return namingScheme_.empty() || namingScheme_ == "flat" || namingScheme_ == "legacy";
+}
+
+std::string PathGenerator::GetExtension(OrthancPluginContentType type, bool encryptionEnabled)
+{
+  std::string extension;
+
+  switch (type)
+  {
+    case OrthancPluginContentType_Dicom:
+      extension = ".dcm";
+      break;
+    case OrthancPluginContentType_DicomAsJson:
+      extension = ".json";
+      break;
+    case OrthancPluginContentType_DicomUntilPixelData:
+      extension = ".dcm.head";
+      break;
+    default:
+      extension = ".unk";
+      break;
+  }
+
+  if (encryptionEnabled)
+  {
+    extension += ".enc";
+  }
+
+  return extension;
+}
+
+std::string PathGenerator::GetPathFromTags(const Json::Value& tags,
+                                           const char* uuid,
+                                           OrthancPluginContentType type,
+                                           bool encryptionEnabled)
+{
+  if (IsDefaultNamingScheme())
+  {
+    // Return empty to indicate default path generation should be used
+    return "";
+  }
+
+  // If tags are null/empty, we cannot generate a custom path
+  // This happens for non-DICOM attachments when tags weren't provided
+  // In that case, fall back to default path generation
+  if (tags.isNull() || tags.empty())
+  {
+    LOG(INFO) << "PathGenerator: No tags available for attachment " << uuid
+              << ", using default path";
+    return "";
+  }
+
+  InitializeTagKeywords();
+
+  std::string path = namingScheme_;
+
+  // Replace {UUID}
+  boost::replace_all(path, "{UUID}", uuid);
+
+  // Replace {.ext} with appropriate extension for this content type
+  boost::replace_all(path, "{.ext}", GetExtension(type, encryptionEnabled));
+
+  // Replace DICOM tag placeholders in hex format {XXXX,YYYY}
+  // Static regex - compiled once for performance
+  static const std::regex hexTagRegex("\\{([0-9A-Fa-f]{4}),([0-9A-Fa-f]{4})\\}");
+  std::smatch match;
+  std::string temp = path;
+
+  while (std::regex_search(temp, match, hexTagRegex))
+  {
+    std::string fullMatch = match[0].str();
+    std::string hexTag = match[1].str() + "," + match[2].str();
+
+    // Convert to lowercase for comparison
+    std::transform(hexTag.begin(), hexTag.end(), hexTag.begin(), ::tolower);
+
+    std::string value = GetTagValueByHex(tags, hexTag);
+    if (value.empty())
+    {
+      value = "UNKNOWN";
+    }
+
+    boost::replace_all(path, fullMatch, SanitizeForPath(value));
+    temp = match.suffix().str();
+  }
+
+  // Replace keyword-based placeholders
+  for (const auto& pair : dicomTagKeywords_)
+  {
+    std::string placeholder = "{" + pair.first + "}";
+    if (path.find(placeholder) != std::string::npos)
+    {
+      std::string value = GetTagValueFromJson(tags, pair.first);
+      if (value.empty())
+      {
+        value = "NO_" + pair.first;
+      }
+      boost::replace_all(path, placeholder, SanitizeForPath(value));
+    }
+  }
+
+  // Handle special formatted dates like {split(StudyDate)} -> YYYY/MM/DD
+  if (path.find("{split(StudyDate)}") != std::string::npos)
+  {
+    std::string date = GetTagValueFromJson(tags, "StudyDate");
+    if (date.size() == 8)
+    {
+      std::string formatted = date.substr(0, 4) + "/" + date.substr(4, 2) + "/" + date.substr(6, 2);
+      boost::replace_all(path, "{split(StudyDate)}", formatted);
+    }
+    else
+    {
+      boost::replace_all(path, "{split(StudyDate)}", "NO_DATE");
+    }
+  }
+
+  // Clean up any double slashes
+  while (path.find("//") != std::string::npos)
+  {
+    boost::replace_all(path, "//", "/");
+  }
+
+  // Remove leading slash if present
+  if (!path.empty() && path[0] == '/')
+  {
+    path = path.substr(1);
+  }
+
+  // Validate path length if configured
+  if (maxPathLength_ > 0 && path.size() > maxPathLength_)
+  {
+    LOG(ERROR) << "PathGenerator: Generated path exceeds maximum length ("
+               << path.size() << " > " << maxPathLength_ << " bytes): " << path;
+    throw Orthanc::OrthancException(Orthanc::ErrorCode_ParameterOutOfRange,
+      "Generated storage path exceeds MaxPathLength limit (" +
+      boost::lexical_cast<std::string>(path.size()) + " > " +
+      boost::lexical_cast<std::string>(maxPathLength_) + " bytes)");
+  }
+
+  LOG(INFO) << "PathGenerator: Generated path for " << uuid << ": " << path;
+
+  return path;
+}

--- a/Plugins/orthanc-s3-namingscheme/Common/PathGenerator.h
+++ b/Plugins/orthanc-s3-namingscheme/Common/PathGenerator.h
@@ -1,0 +1,53 @@
+/**
+ * Cloud storage plugins for Orthanc
+ * Copyright (C) 2020-2023 Osimis S.A., Belgium
+ * Copyright (C) 2024-2026 Orthanc Team SRL, Belgium
+ * Copyright (C) 2021-2026 Sebastien Jodogne, ICTEAM UCLouvain, Belgium
+ *
+ * This program is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ **/
+
+#pragma once
+
+#include <orthanc/OrthancCPlugin.h>
+#include <json/value.h>
+#include <string>
+
+/**
+ * PathGenerator - Generates custom storage paths from DICOM tags
+ *
+ * Known S3-compatible provider path length limits (as of 2025):
+ *   - AWS S3:           1024 bytes
+ *   - Backblaze B2:     1024 bytes
+ *   - Google Cloud:     1024 bytes
+ *   - Azure Blob:       1024 bytes
+ *   - MinIO:            Varies by backend filesystem
+ *   - Wasabi:           1024 bytes
+ *   - DigitalOcean:     1024 bytes
+ *
+ * Recommendation: Set MaxPathLength to 900 to leave margin for RootPath prefix.
+ * These limits may change - check your provider's current documentation.
+ */
+class PathGenerator
+{
+public:
+  static void SetNamingScheme(const std::string& namingScheme);
+  static void SetMaxPathLength(size_t maxLength);
+  static bool IsDefaultNamingScheme();
+  static std::string GetPathFromTags(const Json::Value& tags,
+                                     const char* uuid,
+                                     OrthancPluginContentType type,
+                                     bool encryptionEnabled);
+  static std::string GetExtension(OrthancPluginContentType type, bool encryptionEnabled);
+};

--- a/Plugins/orthanc-s3-namingscheme/Common/StoragePlugin.cpp
+++ b/Plugins/orthanc-s3-namingscheme/Common/StoragePlugin.cpp
@@ -1,0 +1,1216 @@
+/**
+ * Cloud storage plugins for Orthanc
+ * Copyright (C) 2020-2023 Osimis S.A., Belgium
+ * Copyright (C) 2024-2026 Orthanc Team SRL, Belgium
+ * Copyright (C) 2021-2026 Sebastien Jodogne, ICTEAM UCLouvain, Belgium
+ *
+ * This program is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ **/
+
+
+#if GOOGLE_STORAGE_PLUGIN==1
+#  include "../Google/GoogleStoragePlugin.h"
+#  define StoragePluginFactory GoogleStoragePluginFactory
+#elif AZURE_STORAGE_PLUGIN==1
+#  include "../Azure/AzureBlobStoragePlugin.h"
+#  define StoragePluginFactory AzureBlobStoragePluginFactory
+#elif AWS_STORAGE_PLUGIN==1
+#  include "../Aws/AwsS3StoragePlugin.h"
+#  define StoragePluginFactory AwsS3StoragePluginFactory
+#else
+#  pragma message(error  "define a plugin")
+#endif
+
+#include <string.h>
+#include <stdio.h>
+#include <string>
+
+#include <iostream>
+#include <boost/filesystem.hpp>
+#include <boost/filesystem/fstream.hpp>
+
+#include "../Common/EncryptionHelpers.h"
+#include "../Common/EncryptionConfigurator.h"
+#include "../Common/FileSystemStorage.h"
+#include "../Common/PathGenerator.h"
+
+#include <Logging.h>
+#include <SystemToolbox.h>
+#include "MoveStorageJob.h"
+#include "StoragePlugin.h"
+#include <Toolbox.h>
+
+#ifdef _WIN32
+// This is a hotfix for: https://orthanc.uclouvain.be/hg/orthanc/rev/e4d9a872998f
+#  undef ORTHANC_PLUGINS_API
+#  define ORTHANC_PLUGINS_API __declspec(dllexport)
+#endif
+
+
+static std::unique_ptr<IStorage> primaryStorage;
+static std::unique_ptr<IStorage> secondaryStorage;
+
+static std::unique_ptr<EncryptionHelpers> crypto;
+static bool cryptoEnabled = false;
+static std::string fileSystemRootPath;
+static std::string objectsRootPath;
+static std::string hybridModeNameForLogs = "";
+static bool useCustomNamingScheme = false;
+
+typedef enum
+{
+  HybridMode_WriteToFileSystem,       // write to disk, try to read first from disk and then, from object-storage
+  HybridMode_WriteToObjectStorage,    // write to object storage, try to read first from object storage and then, from disk
+  HybridMode_WriteRedundant,          // write to BOTH disk and object-storage, read from disk first then object-storage
+  HybridMode_Disabled                 // read and write only from/to object-storage
+} HybridMode;  
+
+static HybridMode hybridMode = HybridMode_Disabled;
+
+static bool IsReadFromDisk()
+{
+  return hybridMode != HybridMode_Disabled;
+}
+
+static bool IsHybridModeEnabled()
+{
+  return hybridMode != HybridMode_Disabled;
+}
+
+typedef void LogErrorFunction(const std::string& message);
+
+static void LogErrorAsWarning(const std::string& message)
+{
+  LOG(WARNING) << message;
+}
+
+static void LogErrorAsError(const std::string& message)
+{
+  LOG(ERROR) << message;
+}
+
+
+
+static OrthancPluginErrorCode StorageCreate(const char* uuid,
+                                            const void* content,
+                                            int64_t size,
+                                            OrthancPluginContentType type)
+{
+  try
+  {
+    Orthanc::Toolbox::ElapsedTimer timer;
+    LOG(INFO) << primaryStorage->GetNameForLogs() << ": creating attachment " << uuid
+              << " of type " << boost::lexical_cast<std::string>(type);
+    std::unique_ptr<IStorage::IWriter> writer(primaryStorage->GetWriterForObject(uuid, type, cryptoEnabled));
+
+    std::string encryptedData;
+    if (cryptoEnabled)
+    {
+      try
+      {
+        crypto->Encrypt(encryptedData, (const char*)content, size);
+      }
+      catch (EncryptionException& ex)
+      {
+        LOG(ERROR) << primaryStorage->GetNameForLogs() << ": error while encrypting object " << uuid << ": " << ex.what();
+        return OrthancPluginErrorCode_StorageAreaPlugin;
+      }
+
+      writer->Write(encryptedData.data(), encryptedData.size());
+    }
+    else
+    {
+      // No encryption: write directly from source pointer, avoiding memory copy
+      writer->Write(reinterpret_cast<const char*>(content), size);
+    }
+    LOG(INFO) << primaryStorage->GetNameForLogs() << ": created attachment " << uuid
+              << " (" << timer.GetHumanTransferSpeed(true, size) << ")";
+
+    // WriteRedundant: also write to secondary storage - MUST succeed for redundancy guarantee
+    if (hybridMode == HybridMode_WriteRedundant && secondaryStorage.get() != nullptr)
+    {
+      try
+      {
+        LOG(INFO) << secondaryStorage->GetNameForLogs() << ": creating redundant copy of attachment " << uuid;
+        std::unique_ptr<IStorage::IWriter> secondaryWriter(secondaryStorage->GetWriterForObject(uuid, type, cryptoEnabled));
+        if (cryptoEnabled)
+        {
+          secondaryWriter->Write(encryptedData.data(), encryptedData.size());
+        }
+        else
+        {
+          secondaryWriter->Write(reinterpret_cast<const char*>(content), size);
+        }
+        LOG(INFO) << secondaryStorage->GetNameForLogs() << ": created redundant copy of attachment " << uuid;
+      }
+      catch (StoragePluginException& ex)
+      {
+        // Redundancy mode requires BOTH writes to succeed
+        // Primary file is kept (data not lost) but operation fails so Orthanc knows
+        LOG(ERROR) << secondaryStorage->GetNameForLogs() << ": FAILED to create redundant copy of object " << uuid << ": " << ex.what();
+        LOG(ERROR) << "WriteRedundant mode: secondary write failed. Primary file exists at " << primaryStorage->GetNameForLogs()
+                   << " but redundancy is NOT guaranteed. Manual intervention required.";
+        return OrthancPluginErrorCode_StorageAreaPlugin;
+      }
+    }
+  }
+  catch (StoragePluginException& ex)
+  {
+    LOG(ERROR) << primaryStorage->GetNameForLogs() << ": error while creating object " << uuid << ": " << ex.what();
+    return OrthancPluginErrorCode_StorageAreaPlugin;
+  }
+
+  return OrthancPluginErrorCode_Success;
+}
+
+
+static OrthancPluginErrorCode StorageReadRange(IStorage* storage,
+                                               LogErrorFunction logErrorFunction,
+                                               OrthancPluginMemoryBuffer64* target, // Memory buffer where to store the content of the range.  The memory buffer is allocated and freed by Orthanc. The length of the range of interest corresponds to the size of this buffer.
+                                               const char* uuid,
+                                               OrthancPluginContentType type,
+                                               uint64_t rangeStart)
+{
+  assert(!cryptoEnabled);
+
+  try
+  {
+    Orthanc::Toolbox::ElapsedTimer timer;
+    LOG(INFO) << storage->GetNameForLogs() << ": reading range of attachment " << uuid
+              << " of type " << boost::lexical_cast<std::string>(type);
+    
+    std::unique_ptr<IStorage::IReader> reader(storage->GetReaderForObject(uuid, type, cryptoEnabled));
+    reader->ReadRange(reinterpret_cast<char*>(target->data), target->size, rangeStart);
+    
+    LOG(INFO) << storage->GetNameForLogs() << ": read range of attachment " << uuid
+              << " (" << timer.GetHumanTransferSpeed(true, target->size) << ")";
+    return OrthancPluginErrorCode_Success;
+  }
+  catch (StoragePluginException& ex)
+  {
+    logErrorFunction(std::string(StoragePluginFactory::GetStoragePluginName()) + ": error while reading object " + std::string(uuid) + ": " + std::string(ex.what()));
+    return OrthancPluginErrorCode_StorageAreaPlugin;
+  }
+}
+
+static OrthancPluginErrorCode StorageReadRange(OrthancPluginMemoryBuffer64* target, // Memory buffer where to store the content of the range.  The memory buffer is allocated and freed by Orthanc. The length of the range of interest corresponds to the size of this buffer.
+                                               const char* uuid,
+                                               OrthancPluginContentType type,
+                                               uint64_t rangeStart)
+{
+  OrthancPluginErrorCode res = StorageReadRange(primaryStorage.get(),
+                                                (IsHybridModeEnabled() ? LogErrorAsWarning : LogErrorAsError), // log errors as warning on first try
+                                                target,
+                                                uuid,
+                                                type,
+                                                rangeStart);
+
+  if (res != OrthancPluginErrorCode_Success && IsHybridModeEnabled())
+  {
+    res = StorageReadRange(secondaryStorage.get(),
+                           LogErrorAsError, // log errors as errors on second try
+                           target,
+                           uuid,
+                           type,
+                           rangeStart);
+  }
+  return res;
+}
+
+
+
+static OrthancPluginErrorCode StorageReadWhole(IStorage* storage,
+                                               LogErrorFunction logErrorFunction,
+                                               OrthancPluginMemoryBuffer64* target, // Memory buffer where to store the content of the file. It must be allocated by the plugin using OrthancPluginCreateMemoryBuffer64(). The core of Orthanc will free it.
+                                               const char* uuid,
+                                               OrthancPluginContentType type)
+{
+  try
+  {
+    Orthanc::Toolbox::ElapsedTimer timer;
+    LOG(INFO) << storage->GetNameForLogs() << ": reading whole attachment " << uuid
+              << " of type " << boost::lexical_cast<std::string>(type);
+    std::unique_ptr<IStorage::IReader> reader(storage->GetReaderForObject(uuid, type, cryptoEnabled));
+
+    size_t fileSize = reader->GetSize();
+    size_t size;
+
+    if (cryptoEnabled)
+    {
+      size = fileSize - crypto->OVERHEAD_SIZE;
+    }
+    else
+    {
+      size = fileSize;
+    }
+
+    if (size <= 0)
+    {
+      logErrorFunction(storage->GetNameForLogs() + ": error while reading object " + std::string(uuid) + ", size of file is too small: " + boost::lexical_cast<std::string>(fileSize) + " bytes");
+      return OrthancPluginErrorCode_StorageAreaPlugin;
+    }
+
+    if (OrthancPluginCreateMemoryBuffer64(OrthancPlugins::GetGlobalContext(), target, size) != OrthancPluginErrorCode_Success)
+    {
+      logErrorFunction(storage->GetNameForLogs() + ": error while reading object " + std::string(uuid) + ", cannot allocate memory of size " + boost::lexical_cast<std::string>(size) + " bytes");
+      return OrthancPluginErrorCode_StorageAreaPlugin;
+    }
+
+    if (cryptoEnabled)
+    {
+      std::vector<char> encrypted(fileSize);
+      reader->ReadWhole(encrypted.data(), fileSize);
+
+      try
+      {
+        crypto->Decrypt(reinterpret_cast<char*>(target->data), encrypted.data(), fileSize);
+      }
+      catch (EncryptionException& ex)
+      {
+        logErrorFunction(storage->GetNameForLogs() + ": error while decrypting object " + std::string(uuid) + ": " + ex.what());
+        return OrthancPluginErrorCode_StorageAreaPlugin;
+      }
+    }
+    else
+    {
+      reader->ReadWhole(reinterpret_cast<char*>(target->data), fileSize);
+    }
+
+    LOG(INFO) << storage->GetNameForLogs() << ": read whole attachment " << uuid
+              << " (" << timer.GetHumanTransferSpeed(true, fileSize) << ")";
+  }
+  catch (StoragePluginException& ex)
+  {
+    logErrorFunction(storage->GetNameForLogs() + ": error while reading object " + std::string(uuid) + ": " + ex.what());
+    return OrthancPluginErrorCode_StorageAreaPlugin;
+  }
+
+  return OrthancPluginErrorCode_Success;
+}
+
+static OrthancPluginErrorCode StorageReadWhole(OrthancPluginMemoryBuffer64* target, // Memory buffer where to store the content of the file. It must be allocated by the plugin using OrthancPluginCreateMemoryBuffer64(). The core of Orthanc will free it.
+                                               const char* uuid,
+                                               OrthancPluginContentType type)
+{
+  OrthancPluginErrorCode res = StorageReadWhole(primaryStorage.get(),
+                                                (IsHybridModeEnabled() ? LogErrorAsWarning : LogErrorAsError), // log errors as warning on first try
+                                                target,
+                                                uuid,
+                                                type);
+
+  if (res != OrthancPluginErrorCode_Success && IsHybridModeEnabled())
+  {
+    res = StorageReadWhole(secondaryStorage.get(),
+                           LogErrorAsError, // log errors as errors on second try
+                           target,
+                           uuid,
+                           type);
+  }
+  return res;
+}
+
+static OrthancPluginErrorCode StorageReadWholeLegacy(void** content,
+                                                     int64_t* size,
+                                                     const char* uuid,
+                                                     OrthancPluginContentType type)
+{
+  OrthancPluginMemoryBuffer64 buffer;
+  OrthancPluginErrorCode result = StorageReadWhole(&buffer, uuid, type); // will allocate OrthancPluginMemoryBuffer64
+
+  if (result == OrthancPluginErrorCode_Success)
+  {
+    *size = buffer.size;
+    *content = buffer.data; // orthanc will free the buffer (we don't have to delete it ourselves)
+  }
+
+  return result;
+}
+
+
+static OrthancPluginErrorCode StorageRemove(IStorage* storage,
+                                            LogErrorFunction logErrorFunction,
+                                            const char* uuid,
+                                            OrthancPluginContentType type)
+{
+  try
+  {
+    LOG(INFO) << storage->GetNameForLogs() << ": deleting attachment " << uuid
+              << " of type " << boost::lexical_cast<std::string>(type);
+    storage->DeleteObject(uuid, type, cryptoEnabled);
+
+    // For WriteRedundant, we need to signal to also delete from secondary
+    // For other hybrid modes, only signal if this is the primary storage
+    if ((storage == primaryStorage.get()) && IsHybridModeEnabled() &&
+        hybridMode != HybridMode_WriteRedundant)
+    {
+      // not 100% sure the file has been deleted, try the secondary plugin
+      return OrthancPluginErrorCode_StorageAreaPlugin;
+    }
+
+    return OrthancPluginErrorCode_Success;
+  }
+  catch (StoragePluginException& ex)
+  {
+    logErrorFunction(std::string(StoragePluginFactory::GetStoragePluginName()) + ": error while deleting object " + std::string(uuid) + ": " + std::string(ex.what()));
+    return OrthancPluginErrorCode_StorageAreaPlugin;
+  }
+}
+
+static OrthancPluginErrorCode StorageRemove(const char* uuid,
+                                            OrthancPluginContentType type)
+{
+  OrthancPluginErrorCode res = StorageRemove(primaryStorage.get(),
+                                             (IsHybridModeEnabled() ? LogErrorAsWarning : LogErrorAsError), // log errors as warning on first try
+                                             uuid,
+                                             type);
+
+  // For WriteRedundant: MUST also delete from secondary (file exists in both)
+  if (hybridMode == HybridMode_WriteRedundant && secondaryStorage.get() != nullptr)
+  {
+    try
+    {
+      LOG(INFO) << secondaryStorage->GetNameForLogs() << ": deleting redundant copy of attachment " << uuid;
+      secondaryStorage->DeleteObject(uuid, type, cryptoEnabled);
+      LOG(INFO) << secondaryStorage->GetNameForLogs() << ": deleted redundant copy of attachment " << uuid;
+    }
+    catch (StoragePluginException& ex)
+    {
+      // Redundancy mode requires BOTH deletes to succeed
+      LOG(ERROR) << secondaryStorage->GetNameForLogs() << ": FAILED to delete redundant copy of object " << uuid << ": " << ex.what();
+      LOG(ERROR) << "WriteRedundant mode: secondary delete failed. Primary file deleted but secondary may still exist. Manual cleanup required.";
+      return OrthancPluginErrorCode_StorageAreaPlugin;
+    }
+  }
+  // For other hybrid modes: only try secondary as fallback if primary failed
+  else if (res != OrthancPluginErrorCode_Success && IsHybridModeEnabled())
+  {
+    res = StorageRemove(secondaryStorage.get(),
+                        LogErrorAsError, // log errors as errors on second try
+                        uuid,
+                        type);
+  }
+
+  return res;
+}
+
+
+// ============================================================================
+// StorageArea3 API callbacks (with customData and dicomInstance support)
+// ============================================================================
+
+static OrthancPluginErrorCode StorageCreate3(OrthancPluginMemoryBuffer* customData,
+                                             const char* uuid,
+                                             const void* content,
+                                             uint64_t size,
+                                             OrthancPluginContentType type,
+                                             OrthancPluginCompressionType compressionType,
+                                             const OrthancPluginDicomInstance* dicomInstance)
+{
+  try
+  {
+    Orthanc::Toolbox::ElapsedTimer timer;
+
+    // Extract DICOM tags if available
+    Json::Value tags;
+    std::string customPath;
+
+    if (dicomInstance != NULL && useCustomNamingScheme)
+    {
+      OrthancPlugins::DicomInstance dicom(dicomInstance);
+      dicom.GetSimplifiedJson(tags);
+
+      // Generate custom path from tags
+      customPath = PathGenerator::GetPathFromTags(tags, uuid, type, cryptoEnabled);
+    }
+
+    LOG(INFO) << primaryStorage->GetNameForLogs() << ": creating attachment " << uuid
+              << " of type " << boost::lexical_cast<std::string>(type)
+              << (customPath.empty() ? "" : " (custom path: " + customPath + ")");
+
+    std::unique_ptr<IStorage::IWriter> writer(primaryStorage->GetWriterForObject(uuid, type, cryptoEnabled, customPath));
+
+    std::string encryptedData;
+    if (cryptoEnabled)
+    {
+      try
+      {
+        crypto->Encrypt(encryptedData, (const char*)content, size);
+      }
+      catch (EncryptionException& ex)
+      {
+        LOG(ERROR) << primaryStorage->GetNameForLogs() << ": error while encrypting object " << uuid << ": " << ex.what();
+        return OrthancPluginErrorCode_StorageAreaPlugin;
+      }
+
+      writer->Write(encryptedData.data(), encryptedData.size());
+    }
+    else
+    {
+      // No encryption: write directly from source pointer, avoiding memory copy
+      writer->Write(reinterpret_cast<const char*>(content), size);
+    }
+
+    LOG(INFO) << primaryStorage->GetNameForLogs() << ": created attachment " << uuid
+              << " (" << timer.GetHumanTransferSpeed(true, size) << ")";
+
+    // WriteRedundant: also write to secondary storage - MUST succeed for redundancy guarantee
+    if (hybridMode == HybridMode_WriteRedundant && secondaryStorage.get() != nullptr)
+    {
+      try
+      {
+        LOG(INFO) << secondaryStorage->GetNameForLogs() << ": creating redundant copy of attachment " << uuid
+                  << (customPath.empty() ? "" : " (custom path: " + customPath + ")");
+        std::unique_ptr<IStorage::IWriter> secondaryWriter(secondaryStorage->GetWriterForObject(uuid, type, cryptoEnabled, customPath));
+        if (cryptoEnabled)
+        {
+          secondaryWriter->Write(encryptedData.data(), encryptedData.size());
+        }
+        else
+        {
+          secondaryWriter->Write(reinterpret_cast<const char*>(content), size);
+        }
+        LOG(INFO) << secondaryStorage->GetNameForLogs() << ": created redundant copy of attachment " << uuid;
+      }
+      catch (StoragePluginException& ex)
+      {
+        // Redundancy mode requires BOTH writes to succeed
+        // Primary file is kept (data not lost) but operation fails so Orthanc knows
+        LOG(ERROR) << secondaryStorage->GetNameForLogs() << ": FAILED to create redundant copy of object " << uuid << ": " << ex.what();
+        LOG(ERROR) << "WriteRedundant mode: secondary write failed. Primary file exists at " << primaryStorage->GetNameForLogs()
+                   << " but redundancy is NOT guaranteed. Manual intervention required.";
+        return OrthancPluginErrorCode_StorageAreaPlugin;
+      }
+    }
+
+    // Store the custom path in customData so we can retrieve it during read/delete
+    // Only allocate if customPath is non-empty to avoid zero-size buffer issues
+    if (!customPath.empty())
+    {
+      if (OrthancPluginCreateMemoryBuffer(OrthancPlugins::GetGlobalContext(), customData, customPath.size()) != OrthancPluginErrorCode_Success)
+      {
+        LOG(ERROR) << primaryStorage->GetNameForLogs() << ": error allocating customData for " << uuid;
+        // Clean up orphaned files on allocation failure
+        try
+        {
+          primaryStorage->DeleteObject(uuid, type, cryptoEnabled, customPath);
+          if (hybridMode == HybridMode_WriteRedundant && secondaryStorage.get() != nullptr)
+          {
+            secondaryStorage->DeleteObject(uuid, type, cryptoEnabled, customPath);
+          }
+        }
+        catch (...)
+        {
+          LOG(WARNING) << "Failed to clean up orphaned files after customData allocation failure for " << uuid;
+        }
+        return OrthancPluginErrorCode_StorageAreaPlugin;
+      }
+      memcpy(customData->data, customPath.data(), customPath.size());
+    }
+    else
+    {
+      // Empty customPath - set customData to empty (size 0, data NULL)
+      customData->size = 0;
+      customData->data = NULL;
+    }
+  }
+  catch (StoragePluginException& ex)
+  {
+    LOG(ERROR) << primaryStorage->GetNameForLogs() << ": error while creating object " << uuid << ": " << ex.what();
+    return OrthancPluginErrorCode_StorageAreaPlugin;
+  }
+
+  return OrthancPluginErrorCode_Success;
+}
+
+
+static OrthancPluginErrorCode StorageReadRange3(OrthancPluginMemoryBuffer64* target,
+                                                const char* uuid,
+                                                OrthancPluginContentType type,
+                                                uint64_t rangeStart,
+                                                const void* customData,
+                                                uint32_t customDataSize)
+{
+  // Extract custom path from customData
+  std::string customPath;
+  if (customData != NULL && customDataSize > 0)
+  {
+    customPath = std::string(reinterpret_cast<const char*>(customData), customDataSize);
+  }
+
+  // For encrypted files, we must read the whole file and decrypt, then extract the range
+  if (cryptoEnabled)
+  {
+    try
+    {
+      Orthanc::Toolbox::ElapsedTimer timer;
+      LOG(INFO) << primaryStorage->GetNameForLogs() << ": reading encrypted attachment " << uuid
+                << " (range " << rangeStart << "+" << target->size << ")";
+
+      std::unique_ptr<IStorage::IReader> reader(primaryStorage->GetReaderForObject(uuid, type, cryptoEnabled, customPath));
+      size_t encryptedSize = reader->GetSize();
+      std::string encryptedData(encryptedSize, '\0');
+      reader->ReadWhole(&encryptedData[0], encryptedSize);
+
+      std::string decryptedData;
+      try
+      {
+        crypto->Decrypt(decryptedData, encryptedData);
+      }
+      catch (EncryptionException& ex)
+      {
+        LOG(ERROR) << primaryStorage->GetNameForLogs() << ": error while decrypting object " << uuid << ": " << ex.what();
+        return OrthancPluginErrorCode_StorageAreaPlugin;
+      }
+
+      // Validate range is within decrypted data
+      if (rangeStart + target->size > decryptedData.size())
+      {
+        LOG(ERROR) << primaryStorage->GetNameForLogs() << ": requested range exceeds file size for " << uuid;
+        return OrthancPluginErrorCode_StorageAreaPlugin;
+      }
+
+      memcpy(target->data, decryptedData.data() + rangeStart, target->size);
+
+      LOG(INFO) << primaryStorage->GetNameForLogs() << ": read encrypted attachment " << uuid
+                << " (" << timer.GetHumanTransferSpeed(true, target->size) << ")";
+      return OrthancPluginErrorCode_Success;
+    }
+    catch (StoragePluginException& ex)
+    {
+      // Try secondary storage if hybrid mode enabled
+      if (IsHybridModeEnabled())
+      {
+        try
+        {
+          std::unique_ptr<IStorage::IReader> reader(secondaryStorage->GetReaderForObject(uuid, type, cryptoEnabled, customPath));
+          size_t encryptedSize = reader->GetSize();
+          std::string encryptedData(encryptedSize, '\0');
+          reader->ReadWhole(&encryptedData[0], encryptedSize);
+
+          std::string decryptedData;
+          crypto->Decrypt(decryptedData, encryptedData);
+
+          if (rangeStart + target->size > decryptedData.size())
+          {
+            LOG(ERROR) << secondaryStorage->GetNameForLogs() << ": requested range exceeds file size for " << uuid;
+            return OrthancPluginErrorCode_StorageAreaPlugin;
+          }
+
+          memcpy(target->data, decryptedData.data() + rangeStart, target->size);
+          return OrthancPluginErrorCode_Success;
+        }
+        catch (StoragePluginException& ex2)
+        {
+          LOG(ERROR) << StoragePluginFactory::GetStoragePluginName() << ": error while reading object " << uuid << ": " << ex2.what();
+        }
+        catch (EncryptionException& ex2)
+        {
+          LOG(ERROR) << secondaryStorage->GetNameForLogs() << ": error while decrypting object " << uuid << ": " << ex2.what();
+        }
+      }
+      else
+      {
+        LOG(ERROR) << StoragePluginFactory::GetStoragePluginName() << ": error while reading object " << uuid << ": " << ex.what();
+      }
+      return OrthancPluginErrorCode_StorageAreaPlugin;
+    }
+  }
+
+  // Non-encrypted: direct range read
+  try
+  {
+    Orthanc::Toolbox::ElapsedTimer timer;
+    LOG(INFO) << primaryStorage->GetNameForLogs() << ": reading range of attachment " << uuid
+              << " of type " << boost::lexical_cast<std::string>(type);
+
+    std::unique_ptr<IStorage::IReader> reader(primaryStorage->GetReaderForObject(uuid, type, cryptoEnabled, customPath));
+    reader->ReadRange(reinterpret_cast<char*>(target->data), target->size, rangeStart);
+
+    LOG(INFO) << primaryStorage->GetNameForLogs() << ": read range of attachment " << uuid
+              << " (" << timer.GetHumanTransferSpeed(true, target->size) << ")";
+    return OrthancPluginErrorCode_Success;
+  }
+  catch (StoragePluginException& ex)
+  {
+    // Try secondary storage if hybrid mode enabled
+    if (IsHybridModeEnabled())
+    {
+      try
+      {
+        std::unique_ptr<IStorage::IReader> reader(secondaryStorage->GetReaderForObject(uuid, type, cryptoEnabled, customPath));
+        reader->ReadRange(reinterpret_cast<char*>(target->data), target->size, rangeStart);
+        return OrthancPluginErrorCode_Success;
+      }
+      catch (StoragePluginException& ex2)
+      {
+        LOG(ERROR) << StoragePluginFactory::GetStoragePluginName() << ": error while reading object " << uuid << ": " << ex2.what();
+      }
+    }
+    else
+    {
+      LOG(ERROR) << StoragePluginFactory::GetStoragePluginName() << ": error while reading object " << uuid << ": " << ex.what();
+    }
+    return OrthancPluginErrorCode_StorageAreaPlugin;
+  }
+}
+
+
+static OrthancPluginErrorCode StorageRemove3(const char* uuid,
+                                             OrthancPluginContentType type,
+                                             const void* customData,
+                                             uint32_t customDataSize)
+{
+  // Extract custom path from customData
+  std::string customPath;
+  if (customData != NULL && customDataSize > 0)
+  {
+    customPath = std::string(reinterpret_cast<const char*>(customData), customDataSize);
+  }
+
+  try
+  {
+    LOG(INFO) << primaryStorage->GetNameForLogs() << ": deleting attachment " << uuid
+              << " of type " << boost::lexical_cast<std::string>(type);
+
+    primaryStorage->DeleteObject(uuid, type, cryptoEnabled, customPath);
+    LOG(INFO) << primaryStorage->GetNameForLogs() << ": deleted attachment " << uuid;
+
+    // Handle secondary storage deletion based on mode
+    if (hybridMode == HybridMode_WriteRedundant && secondaryStorage.get() != nullptr)
+    {
+      // WriteRedundant: BOTH deletes must succeed
+      try
+      {
+        LOG(INFO) << secondaryStorage->GetNameForLogs() << ": deleting redundant copy of attachment " << uuid;
+        secondaryStorage->DeleteObject(uuid, type, cryptoEnabled, customPath);
+        LOG(INFO) << secondaryStorage->GetNameForLogs() << ": deleted redundant copy of attachment " << uuid;
+      }
+      catch (StoragePluginException& ex)
+      {
+        LOG(ERROR) << secondaryStorage->GetNameForLogs() << ": FAILED to delete redundant copy of object " << uuid << ": " << ex.what();
+        LOG(ERROR) << "WriteRedundant mode: secondary delete failed. Primary file deleted but secondary may still exist. Manual cleanup required.";
+        return OrthancPluginErrorCode_StorageAreaPlugin;
+      }
+    }
+    else if (IsHybridModeEnabled() && secondaryStorage.get() != nullptr)
+    {
+      // Other hybrid modes: best-effort delete from secondary
+      try
+      {
+        secondaryStorage->DeleteObject(uuid, type, cryptoEnabled, customPath);
+      }
+      catch (...)
+      {
+        // Ignore errors from secondary storage in non-redundant modes
+      }
+    }
+
+    return OrthancPluginErrorCode_Success;
+  }
+  catch (StoragePluginException& ex)
+  {
+    LOG(ERROR) << primaryStorage->GetNameForLogs() << ": error while deleting object " << uuid << ": " << ex.what();
+
+    if (IsHybridModeEnabled() && hybridMode != HybridMode_WriteRedundant)
+    {
+      // Non-redundant hybrid modes: try secondary storage as fallback
+      try
+      {
+        secondaryStorage->DeleteObject(uuid, type, cryptoEnabled, customPath);
+        return OrthancPluginErrorCode_Success;
+      }
+      catch (StoragePluginException& ex2)
+      {
+        LOG(ERROR) << StoragePluginFactory::GetStoragePluginName() << ": error while deleting object from secondary " << uuid << ": " << ex2.what();
+      }
+    }
+    return OrthancPluginErrorCode_StorageAreaPlugin;
+  }
+}
+
+
+static MoveStorageJob* CreateMoveStorageJob(const std::string& targetStorage, const std::vector<std::string>& instances, const Json::Value& resourcesForJobContent)
+{
+  std::unique_ptr<MoveStorageJob> job(new MoveStorageJob(targetStorage, instances, resourcesForJobContent, cryptoEnabled));
+
+  if (hybridMode == HybridMode_WriteToFileSystem)
+  {
+    // WriteToFileSystem: primary=filesystem, secondary=object-storage
+    job->SetStorages(primaryStorage.get(), secondaryStorage.get());
+  }
+  else if (hybridMode == HybridMode_WriteRedundant)
+  {
+    // WriteRedundant: primary=filesystem, secondary=object-storage (same as WriteToFileSystem)
+    job->SetStorages(primaryStorage.get(), secondaryStorage.get());
+  }
+  else
+  {
+    // WriteToObjectStorage: primary=object-storage, secondary=filesystem
+    job->SetStorages(secondaryStorage.get(), primaryStorage.get());
+  }
+
+  return job.release();
+}
+
+
+static void AddResourceForJobContent(Json::Value& resourcesForJobContent /* out */, Orthanc::ResourceType resourceType, const std::string& resourceId)
+{
+  const char* resourceGroup = Orthanc::GetResourceTypeText(resourceType, true, true);
+
+  if (!resourcesForJobContent.isMember(resourceGroup))
+  {
+    resourcesForJobContent[resourceGroup] = Json::arrayValue;
+  }
+  
+  resourcesForJobContent[resourceGroup].append(resourceId);
+}
+
+void MoveStorage(OrthancPluginRestOutput* output,
+                 const char* /*url*/,
+                 const OrthancPluginHttpRequest* request)
+{
+  OrthancPluginContext* context = OrthancPlugins::GetGlobalContext();
+
+  if (request->method != OrthancPluginHttpMethod_Post)
+  {
+    OrthancPluginSendMethodNotAllowed(context, output, "POST");
+    return;
+  }
+
+  Json::Value requestPayload;
+
+  if (!OrthancPlugins::ReadJson(requestPayload, request->body, request->bodySize))
+  {
+    throw Orthanc::OrthancException(Orthanc::ErrorCode_BadFileFormat, "A JSON payload was expected");
+  }
+
+  std::vector<std::string> instances;
+  Json::Value resourcesForJobContent;
+
+  if (requestPayload.type() != Json::objectValue ||
+      !requestPayload.isMember(KEY_RESOURCES) ||
+      requestPayload[KEY_RESOURCES].type() != Json::arrayValue)
+  {
+    throw Orthanc::OrthancException(
+      Orthanc::ErrorCode_BadFileFormat,
+      "A request to the move-storage endpoint must provide a JSON object "
+      "with the field \"" + std::string(KEY_RESOURCES) + 
+      "\" containing an array of resources to be sent");
+  }
+
+  if (!requestPayload.isMember(KEY_TARGET_STORAGE)
+      || requestPayload[KEY_TARGET_STORAGE].type() != Json::stringValue
+      || (requestPayload[KEY_TARGET_STORAGE].asString() != STORAGE_TYPE_FILE_SYSTEM && requestPayload[KEY_TARGET_STORAGE].asString() != STORAGE_TYPE_OBJECT_STORAGE))
+  {
+    throw Orthanc::OrthancException(
+      Orthanc::ErrorCode_BadFileFormat,
+      "A request to the move-storage endpoint must provide a JSON object "
+      "with the field \"" + std::string(KEY_TARGET_STORAGE) + 
+      "\" set to \"" + std::string(STORAGE_TYPE_FILE_SYSTEM) + "\" or \"" + std::string(STORAGE_TYPE_OBJECT_STORAGE) +  "\"");
+  }
+
+  const std::string& targetStorage = requestPayload[KEY_TARGET_STORAGE].asString();
+  const Json::Value& resources = requestPayload[KEY_RESOURCES];
+
+  // Extract information about all the child instances
+  for (Json::Value::ArrayIndex i = 0; i < resources.size(); i++)
+  {
+    if (resources[i].type() != Json::stringValue)
+    {
+      throw Orthanc::OrthancException(Orthanc::ErrorCode_BadFileFormat);
+    }
+
+    std::string resource = resources[i].asString();
+    if (resource.empty())
+    {
+      throw Orthanc::OrthancException(Orthanc::ErrorCode_UnknownResource);
+    }
+
+    // Test whether this resource is an instance
+    Json::Value tmpResource;
+    Json::Value tmpInstances;
+    if (OrthancPlugins::RestApiGet(tmpResource, "/instances/" + resource, false))
+    {
+      instances.push_back(resource);
+      AddResourceForJobContent(resourcesForJobContent, Orthanc::ResourceType_Instance, resource);
+    }
+    // This was not an instance, successively try with series/studies/patients
+    else if ((OrthancPlugins::RestApiGet(tmpResource, "/series/" + resource, false) &&
+              OrthancPlugins::RestApiGet(tmpInstances, "/series/" + resource + "/instances", false)) ||
+             (OrthancPlugins::RestApiGet(tmpResource, "/studies/" + resource, false) &&
+              OrthancPlugins::RestApiGet(tmpInstances, "/studies/" + resource + "/instances", false)) ||
+             (OrthancPlugins::RestApiGet(tmpResource, "/patients/" + resource, false) &&
+              OrthancPlugins::RestApiGet(tmpInstances, "/patients/" + resource + "/instances", false)))
+    {
+      if (tmpInstances.type() != Json::arrayValue)
+      {
+        throw Orthanc::OrthancException(Orthanc::ErrorCode_InternalError);
+      }
+
+      AddResourceForJobContent(resourcesForJobContent, Orthanc::StringToResourceType(tmpResource["Type"].asString().c_str()), resource);
+
+      for (Json::Value::ArrayIndex j = 0; j < tmpInstances.size(); j++)
+      {
+        instances.push_back(tmpInstances[j]["ID"].asString());
+      }
+    }
+    else
+    {
+      throw Orthanc::OrthancException(Orthanc::ErrorCode_UnknownResource);
+    }   
+  }
+
+  LOG(INFO) << "Moving " << instances.size() << " instances to " << targetStorage;
+
+  std::unique_ptr<MoveStorageJob> job(CreateMoveStorageJob(targetStorage, instances, resourcesForJobContent));
+
+  OrthancPlugins::OrthancJob::SubmitFromRestApiPost(output, requestPayload, job.release());
+}
+
+OrthancPluginJob* JobUnserializer(const char* jobType,
+                                  const char* serialized)
+{
+  if (jobType == NULL ||
+      serialized == NULL)
+  {
+    return NULL;
+  }
+
+  std::string type(jobType);
+
+  if (type != JOB_TYPE_MOVE_STORAGE)
+  {
+    return NULL;
+  }
+
+  try
+  {
+    std::string tmp(serialized);
+
+    Json::Value source;
+    if (Orthanc::Toolbox::ReadJson(source, tmp))
+    {
+      std::unique_ptr<OrthancPlugins::OrthancJob> job;
+
+      if (type == JOB_TYPE_MOVE_STORAGE)
+      {
+        std::vector<std::string> instances;
+
+        for (size_t i = 0; i < source[KEY_INSTANCES].size(); ++i)
+        {
+          instances.push_back(source[KEY_INSTANCES][static_cast<int>(i)].asString());
+        }
+
+        job.reset(CreateMoveStorageJob(source[KEY_TARGET_STORAGE].asString(), instances, source[KEY_CONTENT]));
+      }
+
+      if (job.get() == NULL)
+      {
+        throw Orthanc::OrthancException(Orthanc::ErrorCode_InternalError);
+      }
+      else
+      {
+        return OrthancPlugins::OrthancJob::Create(job.release());
+      }
+    }
+    else
+    {
+      throw Orthanc::OrthancException(Orthanc::ErrorCode_BadFileFormat);
+    }
+  }
+  catch (Orthanc::OrthancException& e)
+  {
+    LOG(ERROR) << "Error while unserializing a job from the " << StoragePluginFactory::GetStoragePluginName() << " plugin: "
+               << e.What();
+    return NULL;
+  }
+  catch (...)
+  {
+    LOG(ERROR) << "Error while unserializing a job from the " << StoragePluginFactory::GetStoragePluginName() << " plugin";
+    return NULL;
+  }
+}
+
+
+extern "C"
+{
+  ORTHANC_PLUGINS_API int32_t OrthancPluginInitialize(OrthancPluginContext* context)
+  {
+    OrthancPlugins::SetGlobalContext(context);
+
+#if ORTHANC_FRAMEWORK_VERSION_IS_ABOVE(1, 12, 4)
+    Orthanc::Logging::InitializePluginContext(context, StoragePluginFactory::GetStoragePluginName());
+#elif ORTHANC_FRAMEWORK_VERSION_IS_ABOVE(1, 7, 2)
+    Orthanc::Logging::InitializePluginContext(context);
+#else
+    Orthanc::Logging::Initialize(context);
+#endif
+
+    /* Check the version of the Orthanc core */
+    if (OrthancPluginCheckVersion(context) == 0)
+    {
+      char info[1024];
+      sprintf(info, "Your version of Orthanc (%s) must be above %d.%d.%d to run this plugin",
+              context->orthancVersion,
+              ORTHANC_PLUGINS_MINIMAL_MAJOR_NUMBER,
+              ORTHANC_PLUGINS_MINIMAL_MINOR_NUMBER,
+              ORTHANC_PLUGINS_MINIMAL_REVISION_NUMBER);
+      LOG(ERROR) << info;
+      return -1;
+    }
+
+    Orthanc::InitializeFramework("", false);
+
+    OrthancPlugins::OrthancConfiguration orthancConfig;
+
+    LOG(WARNING) << StoragePluginFactory::GetStoragePluginName() << " plugin is initializing";
+    OrthancPlugins::SetDescription(StoragePluginFactory::GetStoragePluginName(), StoragePluginFactory::GetStorageDescription());
+
+    try
+    {
+      const char* pluginSectionName = StoragePluginFactory::GetConfigurationSectionName();
+      static const char* const ENCRYPTION_SECTION = "StorageEncryption";
+
+      if (!orthancConfig.IsSection(pluginSectionName))
+      {
+        LOG(WARNING) << StoragePluginFactory::GetStoragePluginName() << ": no \"" << pluginSectionName
+                     << "\" section found in configuration, plugin is disabled";
+        return 0;
+      }
+
+      OrthancPlugins::OrthancConfiguration pluginSection;
+      orthancConfig.GetSection(pluginSection, pluginSectionName);
+
+      bool migrationFromFileSystemEnabled = pluginSection.GetBooleanValue("MigrationFromFileSystemEnabled", false);
+      std::string hybridModeString = pluginSection.GetStringValue("HybridMode", "Disabled");
+
+      if (migrationFromFileSystemEnabled && hybridModeString == "Disabled")
+      {
+        hybridMode = HybridMode_WriteToObjectStorage;
+        LOG(WARNING) << StoragePluginFactory::GetStoragePluginName() << ": 'MigrationFromFileSystemEnabled' configuration is deprecated, use 'HybridMode': 'WriteToObjectStorage' instead";
+      }
+      else if (hybridModeString == "WriteToObjectStorage")
+      {
+        hybridMode = HybridMode_WriteToObjectStorage;
+        LOG(WARNING) << StoragePluginFactory::GetStoragePluginName() << ": WriteToObjectStorage HybridMode is enabled: writing to object-storage, try reading first from object-storage and, then, from file system";
+      }
+      else if (hybridModeString == "WriteToFileSystem")
+      {
+        hybridMode = HybridMode_WriteToFileSystem;
+        LOG(WARNING) << StoragePluginFactory::GetStoragePluginName() << ": WriteToFileSystem HybridMode is enabled: writing to file system, try reading first from file system and, then, from object-storage";
+      }
+      else if (hybridModeString == "WriteRedundant")
+      {
+        hybridMode = HybridMode_WriteRedundant;
+        LOG(WARNING) << StoragePluginFactory::GetStoragePluginName() << ": WriteRedundant HybridMode is enabled: writing to BOTH file system and object-storage, reading from file system first then object-storage";
+      }
+      else if (hybridModeString == "Disabled")
+      {
+        hybridMode = HybridMode_Disabled;
+        LOG(WARNING) << StoragePluginFactory::GetStoragePluginName() << ": HybridMode is disabled: writing to object-storage and reading only from object-storage";
+      }
+      else
+      {
+        LOG(ERROR) << StoragePluginFactory::GetStoragePluginName() << ": Invalid HybridMode value: '" << hybridModeString
+                   << "'. Valid options are: Disabled, WriteToFileSystem, WriteToObjectStorage, WriteRedundant";
+        return -1;
+      }
+
+      if (IsReadFromDisk())
+      {
+        fileSystemRootPath = orthancConfig.GetStringValue("StorageDirectory", "OrthancStorageNotDefined");
+        LOG(WARNING) << StoragePluginFactory::GetStoragePluginName() << ": HybridMode: reading from file system is enabled, source: " << fileSystemRootPath;
+      }
+
+      objectsRootPath = pluginSection.GetStringValue("RootPath", std::string());
+
+      if (objectsRootPath.size() >= 1 && objectsRootPath[0] == '/')
+      {
+        LOG(ERROR) << StoragePluginFactory::GetStoragePluginName() << ": The RootPath shall not start with a '/': " << objectsRootPath;
+        return -1;
+      }
+
+      std::string objecstStoragePluginName = StoragePluginFactory::GetStoragePluginName();
+      if (hybridMode == HybridMode_WriteToFileSystem)
+      {
+        objecstStoragePluginName += " (Secondary: object-storage)";
+      }
+      else if (hybridMode == HybridMode_WriteToObjectStorage)
+      {
+        objecstStoragePluginName += " (Primary: object-storage)";
+      }
+      else if (hybridMode == HybridMode_WriteRedundant)
+      {
+        objecstStoragePluginName += " (Redundant: object-storage)";
+      }
+
+      std::unique_ptr<IStorage> objectStoragePlugin(StoragePluginFactory::CreateStorage(objecstStoragePluginName, orthancConfig));
+
+      if (objectStoragePlugin.get() == nullptr)
+      {
+        return -1;
+      }
+
+      objectStoragePlugin->SetRootPath(objectsRootPath);
+
+      std::unique_ptr<IStorage> fileSystemStoragePlugin;
+      if (IsHybridModeEnabled())
+      {
+        bool fsync = orthancConfig.GetBooleanValue("SyncStorageArea", true);
+
+        std::string filesystemStoragePluginName = StoragePluginFactory::GetStoragePluginName();
+        if (hybridMode == HybridMode_WriteToFileSystem)
+        {
+          filesystemStoragePluginName += " (Primary: file-system)";
+        }
+        else if (hybridMode == HybridMode_WriteToObjectStorage)
+        {
+          filesystemStoragePluginName += " (Secondary: file-system)";
+        }
+        else if (hybridMode == HybridMode_WriteRedundant)
+        {
+          filesystemStoragePluginName += " (Redundant: file-system)";
+        }
+
+        fileSystemStoragePlugin.reset(new FileSystemStoragePlugin(filesystemStoragePluginName, fileSystemRootPath, fsync));
+      }
+
+      if (hybridMode == HybridMode_Disabled || hybridMode == HybridMode_WriteToObjectStorage)
+      {
+        primaryStorage.reset(objectStoragePlugin.release());
+
+        if (hybridMode == HybridMode_WriteToObjectStorage)
+        {
+          secondaryStorage.reset(fileSystemStoragePlugin.release());
+        }
+      }
+      else if (hybridMode == HybridMode_WriteToFileSystem)
+      {
+        primaryStorage.reset(fileSystemStoragePlugin.release());
+        secondaryStorage.reset(objectStoragePlugin.release());
+      }
+      else if (hybridMode == HybridMode_WriteRedundant)
+      {
+        // WriteRedundant: filesystem is primary (for fast reads), object-storage is secondary
+        // We write to BOTH, read from filesystem first
+        primaryStorage.reset(fileSystemStoragePlugin.release());
+        secondaryStorage.reset(objectStoragePlugin.release());
+      }
+
+      if (pluginSection.IsSection(ENCRYPTION_SECTION))
+      {
+        OrthancPlugins::OrthancConfiguration cryptoSection;
+        pluginSection.GetSection(cryptoSection, ENCRYPTION_SECTION);
+
+        crypto.reset(EncryptionConfigurator::CreateEncryptionHelpers(cryptoSection));
+        cryptoEnabled = crypto.get() != nullptr;
+      }
+
+      if (cryptoEnabled)
+      {
+        LOG(WARNING) << StoragePluginFactory::GetStoragePluginName() << ": client-side encryption is enabled";
+      }
+      else
+      {
+        LOG(WARNING) << StoragePluginFactory::GetStoragePluginName() << ": client-side encryption is disabled";
+      }
+
+      // Parse NamingScheme configuration
+      std::string namingScheme = pluginSection.GetStringValue("NamingScheme", "");
+      if (!namingScheme.empty() && namingScheme != "flat" && namingScheme != "legacy")
+      {
+        PathGenerator::SetNamingScheme(namingScheme);
+        useCustomNamingScheme = true;
+        LOG(WARNING) << StoragePluginFactory::GetStoragePluginName() << ": Custom NamingScheme enabled: " << namingScheme;
+
+        if (cryptoEnabled)
+        {
+          LOG(WARNING) << StoragePluginFactory::GetStoragePluginName() << ": Note: Encryption is enabled, range reads will not be supported";
+        }
+
+        // Parse MaxPathLength - used to validate generated paths don't exceed provider limits
+        // See PathGenerator.h for known provider limits (most S3-compatible: 1024 bytes)
+        unsigned int maxPathLength = pluginSection.GetUnsignedIntegerValue("MaxPathLength", 0);
+        if (maxPathLength > 0)
+        {
+          PathGenerator::SetMaxPathLength(maxPathLength);
+          LOG(WARNING) << StoragePluginFactory::GetStoragePluginName()
+                       << ": MaxPathLength validation enabled: " << maxPathLength << " bytes";
+        }
+      }
+
+
+      if (IsHybridModeEnabled())
+      {
+        OrthancPlugins::RegisterRestCallback<MoveStorage>("/move-storage", true);
+        OrthancPluginRegisterJobsUnserializer(context, JobUnserializer);
+      }
+
+      // Register storage area callbacks
+      if (useCustomNamingScheme)
+      {
+        // Check Orthanc version - StorageArea3 requires 1.12.8+
+        if (!OrthancPlugins::CheckMinimalOrthancVersion(1, 12, 8))
+        {
+          LOG(ERROR) << StoragePluginFactory::GetStoragePluginName()
+                     << ": NamingScheme requires Orthanc 1.12.8 or higher. "
+                     << "Please upgrade Orthanc or remove the NamingScheme configuration.";
+          return -1;
+        }
+
+        // Use StorageArea3 API for custom naming scheme support
+        LOG(WARNING) << StoragePluginFactory::GetStoragePluginName() << ": Using StorageArea3 API for custom path support (requires Orthanc >= 1.12.8)";
+        OrthancPluginRegisterStorageArea3(context, StorageCreate3, StorageReadRange3, StorageRemove3);
+      }
+      else if (cryptoEnabled)
+      {
+        // with encrypted file, we can not support ReadRange.  Therefore, we register the old interface
+        OrthancPluginRegisterStorageArea(context, StorageCreate, StorageReadWholeLegacy, StorageRemove);
+      }
+      else
+      {
+        OrthancPluginRegisterStorageArea2(context, StorageCreate, StorageReadWhole, StorageReadRange, StorageRemove);
+      }
+    }
+    catch (Orthanc::OrthancException& e)
+    {
+      LOG(ERROR) << "Exception while creating the object storage plugin: " << e.What();
+      return -1;
+    }
+
+    return 0;
+  }
+
+
+  ORTHANC_PLUGINS_API void OrthancPluginFinalize()
+  {
+    LOG(WARNING) << StoragePluginFactory::GetStoragePluginName() << " plugin is finalizing";
+    primaryStorage.reset();
+    secondaryStorage.reset();
+    Orthanc::FinalizeFramework();
+  }
+
+
+  ORTHANC_PLUGINS_API const char* OrthancPluginGetName()
+  {
+    return StoragePluginFactory::GetStoragePluginName();
+  }
+
+
+  ORTHANC_PLUGINS_API const char* OrthancPluginGetVersion()
+  {
+    return PLUGIN_VERSION;
+  }
+}
+

--- a/Plugins/orthanc-s3-namingscheme/README.md
+++ b/Plugins/orthanc-s3-namingscheme/README.md
@@ -1,0 +1,113 @@
+# Orthanc Object Storage Plugin with NamingScheme and WriteRedundant Support
+
+ This is a modified version of the official `orthanc-object-storage`  plugin that adds:
+
+ 1. **Custom NamingScheme** - Store DICOM files using variable based paths
+    -resultingly adds StorageArea3 API support to the plugin
+ 2. **WriteRedundant HybridMode** - Write files to BOTH local filesystem AND object storage for redundancy
+ 3. Adds these features while maintaining backwards compatibility. Custom path only supported on Orthanc >= 1.12.8
+    -utilizes version check validation to ensure compatibility
+
+
+ ## Features
+
+ ### NamingScheme
+
+ Configure custom storage paths using DICOM tags:
+
+ ```json
+ {
+   "AwsS3Storage": {
+     "NamingScheme": "{ResponsibleOrganization}/{StudyDate}/{SOPInstanceUID}{.ext}"
+   }
+ }
+ ```
+
+ Supported placeholders:
+ - `{PatientID}`, `{PatientName}`, `{PatientBirthDate}`, `{PatientSex}`
+ - `{StudyInstanceUID}`, `{StudyDate}`, `{StudyID}`, `{StudyDescription}`, `{AccessionNumber}`
+ - `{SeriesInstanceUID}`, `{SeriesDate}`, `{SeriesDescription}`, `{Modality}`
+ - `{SOPInstanceUID}`, `{InstanceNumber}`
+ - `{ResponsibleOrganization}` (DICOM tag 0010,2299)
+ - `{UUID}` - Orthanc's attachment UUID
+ - `{.ext}` - Appropriate file extension (.dcm, .json, .dcm.head, .dcm.enc)
+ - `{split(StudyDate)}` - Formats date as YYYY/MM/DD
+ - ANY DICOM tag hex notation: `{0010,2299}`, `{0008,0020}`, etc.
+
+ ### WriteRedundant HybridMode
+
+ Store files to both local filesystem AND object storage:
+
+ ```json
+ {
+   "AwsS3Storage": {
+     "HybridMode": "WriteRedundant"
+   }
+ }
+ ```
+
+ This mode:
+ - Writes to BOTH filesystem and object storage on every store
+ - Reads from filesystem first (faster), falls back to object storage
+ - Deletes from both storages
+ - Fails write/delete operation if either write fails (strict redundancy)
+
+ ## Requirements
+
+ - Orthanc >= 1.12.8 (for StorageArea3 API with custom path support)
+ - Original orthanc-object-storage build dependencies
+
+ ## Configuration Example
+
+ ```json
+ {
+   "Plugins": ["/path/to/libOrthancAwsS3Storage.so"],
+   "AwsS3Storage": {
+     "BucketName": "my-dicom-bucket",
+     "Region": "us-west-004",
+     "Endpoint": "s3.us-west-004.backblazeb2.com",
+     "AccessKey": "your-access-key",
+     "SecretKey": "your-secret-key",
+     "VirtualAddressing": false,
+     "HybridMode": "WriteRedundant",
+     "NamingScheme": "{ResponsibleOrganization}/{StudyDate}/{SOPInstanceUID}{.ext}",
+     "MaxPathLength": 900,
+     "EnableLegacyStorageStructure": false,
+     "StorageEncryption": {
+       "Enable": false
+     }
+   }
+ }
+ ```
+
+ ## Building
+
+ Apply these modified files to the official `orthanc-object-storage` repository and build as normal:
+
+ ```bash
+ hg clone https://orthanc.uclouvain.be/hg/orthanc-object-storage/
+ # Copy modified files from this contribution
+ cd orthanc-object-storage
+ mkdir build-aws && cd build-aws
+ cmake ../Aws -DSTATIC_BUILD=ON -DALLOW_DOWNLOADS=ON -DCMAKE_BUILD_TYPE=Release
+ make -j4
+ ```
+
+ ## Files Modified
+
+ From the base `orthanc-object-storage` repository:
+
+ - `Common/StoragePlugin.cpp` - Added StorageArea3 API, NamingScheme, WriteRedundant mode
+ - `Common/IStorage.h` - Added custom path method signatures
+ - `Common/BaseStorage.h/cpp` - Added GetPathWithCustom helper
+ - `Common/FileSystemStorage.h/cpp` - Added custom path support for HybridMode
+ - `Common/PathGenerator.h/cpp` - NEW: Generates paths from DICOM tags
+ - `Aws/AwsS3StoragePlugin.cpp` - Added custom path support
+
+ ## License
+
+ GPLv3 - Same as Orthanc
+
+ ## Author
+
+ R.G. Douglas


### PR DESCRIPTION
Features:
1. **Custom NamingScheme** - Store DICOM files using variable based paths
    -resultingly adds StorageArea3 API support to the plugin
 2. **WriteRedundant HybridMode** - Write files to BOTH local filesystem AND object storage for redundancy
 3. Adds these features while maintaining backwards compatibility. Custom path only supported on Orthanc >= 1.12.8
    -utilizes version check validation to ensure compatibility